### PR TITLE
Fix IPv6 Error on Win10 machine with trunk serve

### DIFF
--- a/Trunk.toml
+++ b/Trunk.toml
@@ -11,3 +11,5 @@ public_url = "./"
 no_spa = true
 # Open a browser tab once the initial build is complete.
 open = true
+# Use IPv4 first - prevents errors on Windows
+addresses = ["127.0.0.1", "::1"]


### PR DESCRIPTION
With a brand new app and this template, I got an error running `trunk serve`. This seems to be due to the use of an IPv6 address which my version of Win10 doesn't seem to support.

```
ERROR error opening browser error=Custom { kind: Other, error: "Launcher "cmd" "/c" "start" "" "http://::1:8080/\" failed with ExitStatus(ExitStatus(1))" }
```

Adding the IPv4 address first in the `Trunk.toml` fixed this.

I'm not sure what impact this would have on other platforms?