### PR TITLE
refactor: replace TextFont struct initialization with from_font_size …

### DIFF
--- a/src/theme/widgets.rs
+++ b/src/theme/widgets.rs
@@ -41,10 +41,7 @@ impl<T: Spawn> Widgets for T {
                 (
                     Name::new("Button Text"),
                     Text(text.into()),
-                    TextFont {
-                        font_size: 40.0,
-                        ..default()
-                    },
+                    TextFont::from_font_size(40.0),
                     TextColor(BUTTON_TEXT),
                 ),
             );
@@ -71,10 +68,7 @@ impl<T: Spawn> Widgets for T {
                 (
                     Name::new("Header Text"),
                     Text(text.into()),
-                    TextFont {
-                        font_size: 40.0,
-                        ..default()
-                    },
+                    TextFont::from_font_size(40.0),
                     TextColor(HEADER_TEXT),
                 ),
             );
@@ -86,10 +80,7 @@ impl<T: Spawn> Widgets for T {
         let entity = self.spawn((
             Name::new("Label"),
             Text(text.into()),
-            TextFont {
-                font_size: 24.0,
-                ..default()
-            },
+            TextFont::from_font_size(24.0),
             TextColor(LABEL_TEXT),
             Node {
                 width: Px(500.0),


### PR DESCRIPTION
…method

- Use TextFont::from_font_size method to create TextFont instances in Widgets implementation
- This change improves code readability for font size initialization