### PR TITLE
Reduce boilerplate for adding additional loadable resources

### DIFF
--- a/src/asset_tracking.rs
+++ b/src/asset_tracking.rs
@@ -40,11 +40,18 @@ impl LoadResource for App {
 type InsertLoadedResource = fn(&mut World, &UntypedHandle);
 
 #[derive(Resource, Default)]
-struct ResourceHandles {
+pub struct ResourceHandles {
     // Use a queue for waiting assets so they can be cycled through and moved to
     // `finished` one at a time.
     waiting: VecDeque<(UntypedHandle, InsertLoadedResource)>,
     finished: Vec<UntypedHandle>,
+}
+
+impl ResourceHandles {
+    /// Returns true if all requested [`Asset`]s have finished loading and are available as [`Resource`]s.
+    pub fn is_all_done(&self) -> bool {
+        self.waiting.is_empty()
+    }
 }
 
 fn load_resource_assets(world: &mut World) {

--- a/src/screens/loading.rs
+++ b/src/screens/loading.rs
@@ -3,11 +3,7 @@
 
 use bevy::prelude::*;
 
-use crate::{
-    demo::player::PlayerAssets,
-    screens::{credits::CreditsMusic, gameplay::GameplayMusic, Screen},
-    theme::{interaction::InteractionAssets, prelude::*},
-};
+use crate::{asset_tracking::ResourceHandles, screens::Screen, theme::prelude::*};
 
 pub(super) fn plugin(app: &mut App) {
     app.add_systems(OnEnter(Screen::Loading), spawn_loading_screen);
@@ -34,14 +30,6 @@ fn continue_to_title_screen(mut next_screen: ResMut<NextState<Screen>>) {
     next_screen.set(Screen::Title);
 }
 
-fn all_assets_loaded(
-    player_assets: Option<Res<PlayerAssets>>,
-    interaction_assets: Option<Res<InteractionAssets>>,
-    credits_music: Option<Res<CreditsMusic>>,
-    gameplay_music: Option<Res<GameplayMusic>>,
-) -> bool {
-    player_assets.is_some()
-        && interaction_assets.is_some()
-        && credits_music.is_some()
-        && gameplay_music.is_some()
+fn all_assets_loaded(resource_handles: Res<ResourceHandles>) -> bool {
+    resource_handles.is_all_done()
 }


### PR DESCRIPTION
I wanted the ability to add new resources to the asset tracking system without having to explicitly add them to the list in screens::loading::all_assets_loaded each time. This change generalizes the system by using the data ResourceHandles already has about what has been loading and what's left.