### PR TITLE
Migrate to Rust 2024

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "bevy_new_2d"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 license = "MIT OR Apache-2.0 OR CC0-1.0"
 
 [dependencies]

--- a/Cargo.toml.template
+++ b/Cargo.toml.template
@@ -2,7 +2,7 @@
 name = "{{project-name}}"
 authors = ["{{authors}}"]
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 [dependencies]
 bevy = { version = "0.15", features = ["wayland"] }


### PR DESCRIPTION
Fixes https://github.com/TheBevyFlock/bevy_new_2d/issues/337.

This turns out to not require any change to Rust code, just bumping the number in `Cargo.toml`.