### PR TITLE
Enable `nonstandard_macro_braces` lint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,14 +38,14 @@ dev_native = [
 ]
 
 
-# Idiomatic Bevy code often triggers these lints, and the CI workflow treats them as errors.
-# In some cases they may still signal poor code quality however, so consider commenting out these lines.
 [lints.clippy]
 # Bevy supplies arguments to systems via dependency injection, so it's natural for systems to
-# request more than 7 arguments -- which triggers this lint.
+# request more than 7 arguments, which would incorrectly trigger this lint.
 too_many_arguments = "allow"
-# Queries that access many components may trigger this lint.
+# Queries may access many components, which would incorrectly trigger this lint.
 type_complexity = "allow"
+# Make sure macros use their standard braces, such as `[]` for `bevy_ecs::children!`.
+nonstandard_macro_braces = "warn"
 
 
 # Compile with Performance Optimizations:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,9 +40,9 @@ dev_native = [
 
 [lints.clippy]
 # Bevy supplies arguments to systems via dependency injection, so it's natural for systems to
-# request more than 7 arguments, which would incorrectly trigger this lint.
+# request more than 7 arguments, which would undesirably trigger this lint.
 too_many_arguments = "allow"
-# Queries may access many components, which would incorrectly trigger this lint.
+# Queries may access many components, which would undesirably trigger this lint.
 type_complexity = "allow"
 # Make sure macros use their standard braces, such as `[]` for `bevy_ecs::children!`.
 nonstandard_macro_braces = "warn"

--- a/Cargo.toml.template
+++ b/Cargo.toml.template
@@ -38,14 +38,14 @@ dev_native = [
 ]
 
 
-# Idiomatic Bevy code often triggers these lints, and the CI workflow treats them as errors.
-# In some cases they may still signal poor code quality however, so consider commenting out these lines.
 [lints.clippy]
 # Bevy supplies arguments to systems via dependency injection, so it's natural for systems to
-# request more than 7 arguments -- which triggers this lint.
+# request more than 7 arguments, which would undesirably trigger this lint.
 too_many_arguments = "allow"
-# Queries that access many components may trigger this lint.
+# Queries may access many components, which would undesirably trigger this lint.
 type_complexity = "allow"
+# Make sure macros use their standard braces, such as `[]` for `bevy_ecs::children!`.
+nonstandard_macro_braces = "warn"
 
 
 # Compile with Performance Optimizations:

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,0 +1,2 @@
+# Require `bevy_ecs::children!` to use `[]` braces, instead of `()` or `{}`.
+standard-macro-braces = [{ name = "children", brace = "[" }]


### PR DESCRIPTION
Fixes https://github.com/TheBevyFlock/bevy_new_2d/issues/326.

See the PR enabling this lint in Bevy itself: https://github.com/bevyengine/bevy/pull/17974.