### PR TITLE
Fix `lib.rs.template`

### DIFF
--- a/src/lib.rs.template
+++ b/src/lib.rs.template
@@ -38,9 +38,7 @@ impl Plugin for AppPlugin {
                 .set(WindowPlugin {
                     primary_window: Window {
                         title: "{{project-name | title_case}}".to_string(),
-                        canvas: Some("#bevy".to_string()),
                         fit_canvas_to_parent: true,
-                        prevent_default_event_handling: true,
                         ..default()
                     }
                     .into(),
@@ -48,7 +46,7 @@ impl Plugin for AppPlugin {
                 })
                 .set(AudioPlugin {
                     global_volume: GlobalVolume {
-                        volume: Volume::new(0.3),
+                        volume: Volume::Linear(0.3),
                     },
                     ..default()
                 }),


### PR DESCRIPTION
In https://github.com/TheBevyFlock/bevy_new_2d/pull/312 and https://github.com/TheBevyFlock/bevy_new_2d/pull/339, some changes were made to `lib.rs` but were forgotten to be copied over the `lib.rs.template`, resulting in broken projects.

