### PR TITLE
Prefer `with_child` over `with_children`

### DIFF
--- a/src/screens/credits.rs
+++ b/src/screens/credits.rs
@@ -16,18 +16,18 @@ fn spawn_credits_screen(mut commands: Commands) {
     commands
         .ui_root()
         .insert(StateScoped(Screen::Credits))
-        .with_children(|children| {
-            children.header("Made by");
-            children.label("Joe Shmoe - Implemented aligator wrestling AI");
-            children.label("Jane Doe - Made the music for the alien invasion");
+        .with_children(|parent| {
+            parent.header("Made by");
+            parent.label("Joe Shmoe - Implemented aligator wrestling AI");
+            parent.label("Jane Doe - Made the music for the alien invasion");
 
-            children.header("Assets");
-            children.label("Bevy logo - All rights reserved by the Bevy Foundation. Permission granted for splash screen use when unmodified.");
-            children.label("Ducky sprite - CC0 by Caz Creates Games");
-            children.label("Button SFX - CC0 by Jaszunio15");
-            children.label("Music - CC BY 3.0 by Kevin MacLeod");
+            parent.header("Assets");
+            parent.label("Bevy logo - All rights reserved by the Bevy Foundation. Permission granted for splash screen use when unmodified.");
+            parent.label("Ducky sprite - CC0 by Caz Creates Games");
+            parent.label("Button SFX - CC0 by Jaszunio15");
+            parent.label("Music - CC BY 3.0 by Kevin MacLeod");
 
-            children.button("Back").observe(enter_title_screen);
+            parent.button("Back").observe(enter_title_screen);
         });
 }
 

--- a/src/screens/loading.rs
+++ b/src/screens/loading.rs
@@ -18,8 +18,8 @@ fn spawn_loading_screen(mut commands: Commands) {
     commands
         .ui_root()
         .insert(StateScoped(Screen::Loading))
-        .with_children(|children| {
-            children.label("Loading...").insert(Node {
+        .with_children(|parent| {
+            parent.label("Loading...").insert(Node {
                 justify_content: JustifyContent::Center,
                 ..default()
             });

--- a/src/screens/splash.rs
+++ b/src/screens/splash.rs
@@ -56,31 +56,29 @@ fn spawn_splash_screen(mut commands: Commands, asset_server: Res<AssetServer>) {
             BackgroundColor(SPLASH_BACKGROUND_COLOR),
             StateScoped(Screen::Splash),
         ))
-        .with_children(|children| {
-            children.spawn((
-                Name::new("Splash image"),
-                Node {
-                    margin: UiRect::all(Val::Auto),
-                    width: Val::Percent(70.0),
-                    ..default()
+        .with_child((
+            Name::new("Splash image"),
+            Node {
+                margin: UiRect::all(Val::Auto),
+                width: Val::Percent(70.0),
+                ..default()
+            },
+            ImageNode::new(asset_server.load_with_settings(
+                // This should be an embedded asset for instant loading, but that is
+                // currently [broken on Windows Wasm builds](https://github.com/bevyengine/bevy/issues/14246).
+                "images/splash.png",
+                |settings: &mut ImageLoaderSettings| {
+                    // Make an exception for the splash image in case
+                    // `ImagePlugin::default_nearest()` is used for pixel art.
+                    settings.sampler = ImageSampler::linear();
                 },
-                ImageNode::new(asset_server.load_with_settings(
-                    // This should be an embedded asset for instant loading, but that is
-                    // currently [broken on Windows Wasm builds](https://github.com/bevyengine/bevy/issues/14246).
-                    "images/splash.png",
-                    |settings: &mut ImageLoaderSettings| {
-                        // Make an exception for the splash image in case
-                        // `ImagePlugin::default_nearest()` is used for pixel art.
-                        settings.sampler = ImageSampler::linear();
-                    },
-                )),
-                ImageNodeFadeInOut {
-                    total_duration: SPLASH_DURATION_SECS,
-                    fade_duration: SPLASH_FADE_DURATION_SECS,
-                    t: 0.0,
-                },
-            ));
-        });
+            )),
+            ImageNodeFadeInOut {
+                total_duration: SPLASH_DURATION_SECS,
+                fade_duration: SPLASH_FADE_DURATION_SECS,
+                t: 0.0,
+            },
+        ));
 }
 
 #[derive(Component, Reflect)]

--- a/src/screens/title.rs
+++ b/src/screens/title.rs
@@ -12,12 +12,12 @@ fn spawn_title_screen(mut commands: Commands) {
     commands
         .ui_root()
         .insert(StateScoped(Screen::Title))
-        .with_children(|children| {
-            children.button("Play").observe(enter_gameplay_screen);
-            children.button("Credits").observe(enter_credits_screen);
+        .with_children(|parent| {
+            parent.button("Play").observe(enter_gameplay_screen);
+            parent.button("Credits").observe(enter_credits_screen);
 
             #[cfg(not(target_family = "wasm"))]
-            children.button("Exit").observe(exit_app);
+            parent.button("Exit").observe(exit_app);
         });
 }
 

--- a/src/theme/widgets.rs
+++ b/src/theme/widgets.rs
@@ -42,14 +42,12 @@ impl<T: Spawn> Widgets for T {
                 pressed: BUTTON_PRESSED_BACKGROUND,
             },
         ));
-        entity.with_children(|children| {
-            children.spawn((
-                Name::new("Button Text"),
-                Text(text.into()),
-                TextFont::from_font_size(40.0),
-                TextColor(BUTTON_TEXT),
-            ));
-        });
+        entity.with_child((
+            Name::new("Button Text"),
+            Text(text.into()),
+            TextFont::from_font_size(40.0),
+            TextColor(BUTTON_TEXT),
+        ));
 
         entity
     }
@@ -66,14 +64,13 @@ impl<T: Spawn> Widgets for T {
             },
             BackgroundColor(NODE_BACKGROUND),
         ));
-        entity.with_children(|children| {
-            children.spawn((
-                Name::new("Header Text"),
-                Text(text.into()),
-                TextFont::from_font_size(40.0),
-                TextColor(HEADER_TEXT),
-            ));
-        });
+        entity.with_child((
+            Name::new("Header Text"),
+            Text(text.into()),
+            TextFont::from_font_size(40.0),
+            TextColor(HEADER_TEXT),
+        ));
+
         entity
     }
 

--- a/src/theme/widgets.rs
+++ b/src/theme/widgets.rs
@@ -75,7 +75,7 @@ impl<T: Spawn> Widgets for T {
     }
 
     fn label(&mut self, text: impl Into<String>) -> EntityCommands {
-        let entity = self.spawn((
+        self.spawn((
             Name::new("Label"),
             Text(text.into()),
             TextFont::from_font_size(24.0),
@@ -84,8 +84,7 @@ impl<T: Spawn> Widgets for T {
                 width: Px(500.0),
                 ..default()
             },
-        ));
-        entity
+        ))
     }
 }
 


### PR DESCRIPTION
Also renamed the closure argument in `with_children` from `children` to `parent`, because that's the most common name used in `bevy` itself (there were 0 instances of `children`; the second-most common name was `builder`).