### PR TITLE
Update asset loading docs (plus some cleanup)

### DIFF
--- a/src/demo/player.rs
+++ b/src/demo/player.rs
@@ -19,6 +19,8 @@ use crate::{
 
 pub(super) fn plugin(app: &mut App) {
     app.register_type::<Player>();
+
+    app.register_type::<PlayerAssets>();
     app.load_resource::<PlayerAssets>();
 
     // Record directional input as movement controls.
@@ -112,22 +114,13 @@ fn record_player_directional_input(
     }
 }
 
-#[derive(Resource, Asset, Reflect, Clone)]
+#[derive(Resource, Asset, Clone, Reflect)]
+#[reflect(Resource)]
 pub struct PlayerAssets {
-    // This #[dependency] attribute marks the field as a dependency of the Asset.
-    // This means that it will not finish loading until the labeled asset is also loaded.
     #[dependency]
-    pub ducky: Handle<Image>,
+    ducky: Handle<Image>,
     #[dependency]
     pub steps: Vec<Handle<AudioSource>>,
-}
-
-impl PlayerAssets {
-    pub const PATH_DUCKY: &'static str = "images/ducky.png";
-    pub const PATH_STEP_1: &'static str = "audio/sound_effects/step1.ogg";
-    pub const PATH_STEP_2: &'static str = "audio/sound_effects/step2.ogg";
-    pub const PATH_STEP_3: &'static str = "audio/sound_effects/step3.ogg";
-    pub const PATH_STEP_4: &'static str = "audio/sound_effects/step4.ogg";
 }
 
 impl FromWorld for PlayerAssets {
@@ -135,17 +128,17 @@ impl FromWorld for PlayerAssets {
         let assets = world.resource::<AssetServer>();
         Self {
             ducky: assets.load_with_settings(
-                PlayerAssets::PATH_DUCKY,
+                "images/ducky.png",
                 |settings: &mut ImageLoaderSettings| {
                     // Use `nearest` image sampling to preserve the pixel art style.
                     settings.sampler = ImageSampler::nearest();
                 },
             ),
             steps: vec![
-                assets.load(PlayerAssets::PATH_STEP_1),
-                assets.load(PlayerAssets::PATH_STEP_2),
-                assets.load(PlayerAssets::PATH_STEP_3),
-                assets.load(PlayerAssets::PATH_STEP_4),
+                assets.load("audio/sound_effects/step1.ogg"),
+                assets.load("audio/sound_effects/step2.ogg"),
+                assets.load("audio/sound_effects/step3.ogg"),
+                assets.load("audio/sound_effects/step4.ogg"),
             ],
         }
     }

--- a/src/screens/credits.rs
+++ b/src/screens/credits.rs
@@ -7,9 +7,10 @@ use crate::{asset_tracking::LoadResource, audio::Music, screens::Screen, theme::
 pub(super) fn plugin(app: &mut App) {
     app.add_systems(OnEnter(Screen::Credits), spawn_credits_screen);
 
+    app.register_type::<CreditsMusic>();
     app.load_resource::<CreditsMusic>();
-    app.add_systems(OnEnter(Screen::Credits), play_credits_music);
-    app.add_systems(OnExit(Screen::Credits), stop_music);
+    app.add_systems(OnEnter(Screen::Credits), start_credits_music);
+    app.add_systems(OnExit(Screen::Credits), stop_credits_music);
 }
 
 fn spawn_credits_screen(mut commands: Commands) {
@@ -35,8 +36,9 @@ fn enter_title_screen(_: Trigger<Pointer<Pressed>>, mut next_screen: ResMut<Next
     next_screen.set(Screen::Title);
 }
 
-#[derive(Resource, Asset, Reflect, Clone)]
-pub struct CreditsMusic {
+#[derive(Resource, Asset, Clone, Reflect)]
+#[reflect(Resource)]
+struct CreditsMusic {
     #[dependency]
     music: Handle<AudioSource>,
     entity: Option<Entity>,
@@ -52,7 +54,7 @@ impl FromWorld for CreditsMusic {
     }
 }
 
-fn play_credits_music(mut commands: Commands, mut music: ResMut<CreditsMusic>) {
+fn start_credits_music(mut commands: Commands, mut music: ResMut<CreditsMusic>) {
     music.entity = Some(
         commands
             .spawn((
@@ -64,7 +66,7 @@ fn play_credits_music(mut commands: Commands, mut music: ResMut<CreditsMusic>) {
     );
 }
 
-fn stop_music(mut commands: Commands, mut music: ResMut<CreditsMusic>) {
+fn stop_credits_music(mut commands: Commands, mut music: ResMut<CreditsMusic>) {
     if let Some(entity) = music.entity.take() {
         commands.entity(entity).despawn();
     }

--- a/src/theme/interaction.rs
+++ b/src/theme/interaction.rs
@@ -4,6 +4,7 @@ use crate::{asset_tracking::LoadResource, audio::SoundEffect};
 
 pub(super) fn plugin(app: &mut App) {
     app.register_type::<InteractionPalette>();
+    app.register_type::<InteractionAssets>();
     app.load_resource::<InteractionAssets>();
     app.add_systems(
         Update,
@@ -41,25 +42,21 @@ fn apply_interaction_palette(
     }
 }
 
-#[derive(Resource, Asset, Reflect, Clone)]
-pub struct InteractionAssets {
+#[derive(Resource, Asset, Clone, Reflect)]
+#[reflect(Resource)]
+struct InteractionAssets {
     #[dependency]
     hover: Handle<AudioSource>,
     #[dependency]
     press: Handle<AudioSource>,
 }
 
-impl InteractionAssets {
-    pub const PATH_BUTTON_HOVER: &'static str = "audio/sound_effects/button_hover.ogg";
-    pub const PATH_BUTTON_PRESS: &'static str = "audio/sound_effects/button_press.ogg";
-}
-
 impl FromWorld for InteractionAssets {
     fn from_world(world: &mut World) -> Self {
         let assets = world.resource::<AssetServer>();
         Self {
-            hover: assets.load(Self::PATH_BUTTON_HOVER),
-            press: assets.load(Self::PATH_BUTTON_PRESS),
+            hover: assets.load("audio/sound_effects/button_hover.ogg"),
+            press: assets.load("audio/sound_effects/button_press.ogg"),
         }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/TheBevyFlock/bevy_new_2d/issues/284.

I believe the const `PATH_XYZ` were originally used as keys into a `HashMap`. The newer asset loading pattern uses named struct fields instead of a `HashMap`, so the consts are not needed anymore and can be removed.