### PR TITLE
Improve CI usage awareness

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -68,7 +68,7 @@ env:
   # https://docs.github.com/en/repositories/working-with-files/managing-large-files/about-storage-and-bandwidth-usage
   git_lfs: false
 
-  # This only helps with consecutive releases to the same tag (and takes up cache storage space).
+  # Enabling this only helps with consecutive releases to the same tag (and takes up cache storage space).
   # See: https://github.com/orgs/community/discussions/27059
   use_github_cache: false
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -14,7 +14,7 @@ on:
         required: true
         type: string
 
-# Configure the release workflow by editing these values.
+# Configure the release workflow by editing the following values.
 env:
   # The base filename of the binary produced by `cargo build`.
   cargo_build_binary_name: bevy_new_2d
@@ -61,6 +61,10 @@ env:
   # Before enabling LFS, please take a look at GitHub's documentation for costs and quota limits:
   # https://docs.github.com/en/repositories/working-with-files/managing-large-files/about-storage-and-bandwidth-usage
   git_lfs: false
+
+  # This only helps with consecutive releases to the same tag (and takes up cache storage space).
+  # See: https://github.com/orgs/community/discussions/27059
+  use_github_cache: false
 
 jobs:
   # Determine the version number for this workflow.
@@ -148,6 +152,7 @@ jobs:
           targets: ${{ matrix.targets }}
 
       - name: Populate cargo cache
+        if: ${{ env.use_github_cache == 'true' }}
         uses: Leafwing-Studios/cargo-cache@v2
         with:
           sweep-cache: true

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -22,6 +22,12 @@ env:
   # The path to the assets directory.
   assets_path: assets
 
+  # Whether to build and package a release for a given target platform.
+  build_for_windows: true
+  build_for_macos: true
+  build_for_linux: true
+  build_for_web: true
+
   # Whether to upload the packages produced by this workflow to a GitHub release.
   upload_to_github: true
 
@@ -93,6 +99,7 @@ jobs:
             binary_ext: .wasm
             package_ext: .zip
             runner: ubuntu-latest
+            enabled: ${{ env.build_for_web == 'true' }}
 
           - platform: linux
             targets: x86_64-unknown-linux-gnu
@@ -100,6 +107,7 @@ jobs:
             features: bevy/wayland
             package_ext: .zip
             runner: ubuntu-latest
+            enabled: ${{ env.build_for_linux == 'true' }}
 
           - platform: windows
             targets: x86_64-pc-windows-msvc
@@ -107,6 +115,7 @@ jobs:
             binary_ext: .exe
             package_ext: .zip
             runner: windows-latest
+            enabled: ${{ env.build_for_windows == 'true' }}
 
           - platform: macos
             targets: x86_64-apple-darwin aarch64-apple-darwin
@@ -114,6 +123,8 @@ jobs:
             app_suffix: .app/Contents/MacOS
             package_ext: .dmg
             runner: macos-latest
+            enabled: ${{ env.build_for_macos == 'true' }}
+    if: ${{ matrix.enabled }}
     runs-on: ${{ matrix.runner }}
     permissions:
       # Required to create a GitHub release: https://docs.github.com/en/rest/releases/releases#create-a-release

--- a/.github/workflows/release.yaml.template
+++ b/.github/workflows/release.yaml.template
@@ -10,17 +10,23 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: 'Version number in the format `v1.2.3`'
+        description: "Version number in the format `v1.2.3`"
         required: true
         type: string
 
-# Configure the release workflow by editing these values.
+# Configure the release workflow by editing the following values.
 env:
   # The base filename of the binary produced by `cargo build`.
   cargo_build_binary_name: {{project-name}}
 
   # The path to the assets directory.
   assets_path: assets
+
+  # Whether to build and package a release for a given target platform.
+  build_for_windows: true
+  build_for_macos: true
+  build_for_linux: true
+  build_for_web: true
 
   # Whether to upload the packages produced by this workflow to a GitHub release.
   upload_to_github: true
@@ -70,6 +76,10 @@ env:
   # https://docs.github.com/en/repositories/working-with-files/managing-large-files/about-storage-and-bandwidth-usage
   git_lfs: false
 
+  # This only helps with consecutive releases to the same tag (and takes up cache storage space).
+  # See: https://github.com/orgs/community/discussions/27059
+  use_github_cache: false
+
 {%- raw %}
 jobs:
   # Determine the version number for this workflow.
@@ -98,6 +108,7 @@ jobs:
             binary_ext: .wasm
             package_ext: .zip
             runner: ubuntu-latest
+            enabled: ${{ env.build_for_web == 'true' }}
 
           - platform: linux
             targets: x86_64-unknown-linux-gnu
@@ -105,6 +116,7 @@ jobs:
             features: bevy/wayland
             package_ext: .zip
             runner: ubuntu-latest
+            enabled: ${{ env.build_for_linux == 'true' }}
 
           - platform: windows
             targets: x86_64-pc-windows-msvc
@@ -112,6 +124,7 @@ jobs:
             binary_ext: .exe
             package_ext: .zip
             runner: windows-latest
+            enabled: ${{ env.build_for_windows == 'true' }}
 
           - platform: macos
             targets: x86_64-apple-darwin aarch64-apple-darwin
@@ -119,6 +132,8 @@ jobs:
             app_suffix: .app/Contents/MacOS
             package_ext: .dmg
             runner: macos-latest
+            enabled: ${{ env.build_for_macos == 'true' }}
+    if: ${{ matrix.enabled }}
     runs-on: ${{ matrix.runner }}
     permissions:
       # Required to create a GitHub release: https://docs.github.com/en/rest/releases/releases#create-a-release
@@ -157,6 +172,7 @@ jobs:
           targets: ${{ matrix.targets }}
 
       - name: Populate cargo cache
+        if: ${{ env.use_github_cache == 'true' }}
         uses: Leafwing-Studios/cargo-cache@v2
         with:
           sweep-cache: true
@@ -275,7 +291,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Do nothing
-        run: 'true'
+        run: "true"
     outputs:
       target: ${{ env.upload_to_itch }}
 

--- a/.github/workflows/release.yaml.template
+++ b/.github/workflows/release.yaml.template
@@ -76,7 +76,7 @@ env:
   # https://docs.github.com/en/repositories/working-with-files/managing-large-files/about-storage-and-bandwidth-usage
   git_lfs: false
 
-  # This only helps with consecutive releases to the same tag (and takes up cache storage space).
+  # Enabling this only helps with consecutive releases to the same tag (and takes up cache storage space).
   # See: https://github.com/orgs/community/discussions/27059
   use_github_cache: false
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ This template comes with a basic project structure that you may find useful:
 
 Feel free to move things around however you want, though.
 
-> [!Tip]
+> [!TIP]
 > Be sure to check out the [3rd-party tools](./docs/tooling.md) we recommend!
 
 ## Run your game

--- a/docs/tooling.md
+++ b/docs/tooling.md
@@ -42,7 +42,7 @@ If you're using [VS Code](https://code.visualstudio.com/), the following extensi
 | [Dependi](https://marketplace.visualstudio.com/items?itemName=fill-labs.dependi)                          | `crates.io` dependency resolution |
 | [EditorConfig for VS Code](https://marketplace.visualstudio.com/items?itemName=EditorConfig.EditorConfig) | `.editorconfig` support           |
 
-> [!Note]
+> [!NOTE]
 > <details>
 > <summary>About the included rust-analyzer settings</summary>
 >

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -53,6 +53,12 @@ The release workflow can be configured by tweaking the environment variables in 
   # The path to the assets directory.
   assets_path: assets
 
+  # Whether to build and package a release for a given target platform.
+  build_for_windows: true
+  build_for_macos: true
+  build_for_linux: true
+  build_for_web: true
+
   # Whether to upload the packages produced by this workflow to a GitHub release.
   upload_to_github: true
 

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -92,6 +92,10 @@ The release workflow can be configured by tweaking the environment variables in 
   # Before enabling LFS, please take a look at GitHub's documentation for costs and quota limits:
   # https://docs.github.com/en/repositories/working-with-files/managing-large-files/about-storage-and-bandwidth-usage
   git_lfs: false
+
+  # This only helps with consecutive releases to the same tag (and takes up cache storage space).
+  # See: https://github.com/orgs/community/discussions/27059
+  use_github_cache: false
   ```
 </details>
 

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -11,7 +11,7 @@ The [CI workflow](.github/workflows/ci.yaml) will trigger on every commit or PR 
 - Check formatting.
 - Check documentation.
 
-> [!Tip]
+> [!TIP]
 > <details>
 >   <summary>You may want to set up a <a href="https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-rulesets/about-rulesets">GitHub ruleset</a> to require that all commits to <code>main</code> pass CI.</summary>
 >
@@ -36,7 +36,7 @@ The [CD workflow](../.github/workflows/release.yaml) will trigger on every pushe
   Enter a version number in the format `v1.2.3`, then hit the green `Run workflow` button.
 </details>
 
-> [!Important]
+> [!IMPORTANT]
 > Using this workflow requires some setup. We will go through this now.
 
 ### Configure environment variables
@@ -106,6 +106,9 @@ The release workflow can be configured by tweaking the environment variables in 
 </details>
 
 The initial values are set automatically by `bevy new`, but you can edit them yourself and push a commit.
+
+> [!WARNING]
+> GitHub puts a limit on free CI usage for [private repositories](https://docs.github.com/en/actions/using-github-hosted-runners/using-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for--private-repositories), so tune your workflows accordingly!
 
 ### Set up itch.io upload
 

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -99,7 +99,7 @@ The release workflow can be configured by tweaking the environment variables in 
   # https://docs.github.com/en/repositories/working-with-files/managing-large-files/about-storage-and-bandwidth-usage
   git_lfs: false
 
-  # This only helps with consecutive releases to the same tag (and takes up cache storage space).
+  # Enabling this only helps with consecutive releases to the same tag (and takes up cache storage space).
   # See: https://github.com/orgs/community/discussions/27059
   use_github_cache: false
   ```


### PR DESCRIPTION
Fixes https://github.com/TheBevyFlock/bevy_new_2d/issues/212.

This adds some new flags to the release workflow:
- `use_github_cache` to toggle caching the release workflow, which is now _off_ by default because it unfortunately doesn't do anything unless the user releases multiple times _to the same tag_.
- `build_for_windows` etc. convenience toggles for individual platforms.

These changes can be tested (and fixed if necessary) after this PR is merged.