### PR TITLE
Add some files to `cargo-generate` ignore list

### DIFF
--- a/README.md.template
+++ b/README.md.template
@@ -1,0 +1,4 @@
+# {{project-name | title_case}}
+
+This project was generated using the [Bevy New 2D](https://github.com/TheBevyFlock/bevy_new_2d) template.
+Check out the [documentation](https://github.com/TheBevyFlock/bevy_new_2d/blob/main/README.md) to get started!

--- a/cargo-generate.toml
+++ b/cargo-generate.toml
@@ -1,6 +1,14 @@
 [template]
-ignore = ["target", "Cargo.lock"]
 include = ["*.template"]
+ignore = [
+    "docs",
+    "target",
+    "Cargo.lock",
+    "LICENSE-Apache-2.0.txt",
+    "LICENSE-CC0-1.0.txt",
+    "LICENSE-MIT.txt",
+    "README.md",
+]
 
 [hooks]
 post = ["post-generate.rhai"]

--- a/cargo-generate.toml
+++ b/cargo-generate.toml
@@ -7,7 +7,6 @@ ignore = [
     "LICENSE-Apache-2.0.txt",
     "LICENSE-CC0-1.0.txt",
     "LICENSE-MIT.txt",
-    "README.md",
 ]
 
 [hooks]

--- a/cargo-generate.toml
+++ b/cargo-generate.toml
@@ -1,4 +1,5 @@
 [template]
+cargo_generate_version = "0.23"
 include = ["*.template"]
 ignore = [
     "docs",

--- a/post-generate.rhai
+++ b/post-generate.rhai
@@ -1,6 +1,7 @@
 // Rename template files.
 file::rename(".github/workflows/release.yaml.template", ".github/workflows/release.yaml");
 file::rename("Cargo.toml.template", "Cargo.toml");
+file::rename("README.md.template", "README.md");
 file::rename("src/main.rs.template", "src/main.rs");
 file::rename("src/lib.rs.template", "src/lib.rs");
 file::rename("src/audio.rs.template", "src/audio.rs");


### PR DESCRIPTION
Specifically, ignore license files and documentation. A stub `README.md.template` has been added to point users to this repository for more information.