### PR TITLE
Add config to fix default web and release builds

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -206,7 +206,7 @@ jobs:
         if: ${{ env.is_platform_enabled == 'true' && matrix.platform != 'web' }}
         run: |
           for target in ${{ matrix.targets }}; do
-            cargo build --locked --profile='${{ matrix.profile }}' --target="${target}" --features='${{ matrix.features }}'
+            cargo build --locked --profile='${{ matrix.profile }}' --target="${target}" --no-default-features --features='${{ matrix.features }}'
             mv target/"${target}"/'${{ matrix.profile }}/${{ env.cargo_build_binary_name }}${{ matrix.binary_ext }}' tmp/binary/"${target}"'${{ matrix.binary_ext }}'
           done
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -196,7 +196,7 @@ jobs:
         if: ${{ env.is_platform_enabled == 'true' && matrix.platform == 'web' }}
         run: |
           cargo install --git=https://github.com/TheBevyFlock/bevy_cli --locked bevy_cli
-          bevy build --locked --profile='${{ matrix.profile }}' --release --features='${{ matrix.features }}' --yes web --bundle
+          bevy build --locked --profile='${{ matrix.profile }}' --features='${{ matrix.features }}' --yes web --bundle
 
       - name: Add web bundle to app (Web)
         if: ${{ env.is_platform_enabled == 'true' && matrix.platform == 'web' }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -196,7 +196,7 @@ jobs:
         if: ${{ env.is_platform_enabled == 'true' && matrix.platform == 'web' }}
         run: |
           cargo install --git=https://github.com/TheBevyFlock/bevy_cli --locked bevy_cli
-          bevy build --locked --profile='${{ matrix.profile }}' --no-default-features --features='${{ matrix.features }}' --yes web --bundle
+          bevy build --locked --profile='${{ matrix.profile }}' --release --features='${{ matrix.features }}' --yes web --bundle
 
       - name: Add web bundle to app (Web)
         if: ${{ env.is_platform_enabled == 'true' && matrix.platform == 'web' }}
@@ -206,7 +206,7 @@ jobs:
         if: ${{ env.is_platform_enabled == 'true' && matrix.platform != 'web' }}
         run: |
           for target in ${{ matrix.targets }}; do
-            cargo build --locked --profile='${{ matrix.profile }}' --target="${target}" --no-default-features --features='${{ matrix.features }}'
+            cargo build --locked --profile='${{ matrix.profile }}' --target="${target}" --features='${{ matrix.features }}'
             mv target/"${target}"/'${{ matrix.profile }}/${{ env.cargo_build_binary_name }}${{ matrix.binary_ext }}' tmp/binary/"${target}"'${{ matrix.binary_ext }}'
           done
 

--- a/.github/workflows/release.yaml.template
+++ b/.github/workflows/release.yaml.template
@@ -205,7 +205,7 @@ jobs:
         if: ${{ env.is_platform_enabled == 'true' && matrix.platform == 'web' }}
         run: |
           cargo install --git=https://github.com/TheBevyFlock/bevy_cli --locked bevy_cli
-          bevy build --locked --profile='${{ matrix.profile }}' --no-default-features --features='${{ matrix.features }}' --yes web --bundle
+          bevy build --locked --profile='${{ matrix.profile }}' --features='${{ matrix.features }}' --yes web --bundle
 
       - name: Add web bundle to app (Web)
         if: ${{ env.is_platform_enabled == 'true' && matrix.platform == 'web' }}
@@ -215,7 +215,7 @@ jobs:
         if: ${{ env.is_platform_enabled == 'true' && matrix.platform != 'web' }}
         run: |
           for target in ${{ matrix.targets }}; do
-            cargo build --locked --profile='${{ matrix.profile }}' --target="${target}" --no-default-features --features='${{ matrix.features }}'
+            cargo build --locked --profile='${{ matrix.profile }}' --target="${target}" --features='${{ matrix.features }}'
             mv target/"${target}"/'${{ matrix.profile }}/${{ env.cargo_build_binary_name }}${{ matrix.binary_ext }}' tmp/binary/"${target}"'${{ matrix.binary_ext }}'
           done
 

--- a/.github/workflows/release.yaml.template
+++ b/.github/workflows/release.yaml.template
@@ -215,7 +215,7 @@ jobs:
         if: ${{ env.is_platform_enabled == 'true' && matrix.platform != 'web' }}
         run: |
           for target in ${{ matrix.targets }}; do
-            cargo build --locked --profile='${{ matrix.profile }}' --target="${target}" --features='${{ matrix.features }}'
+            cargo build --locked --profile='${{ matrix.profile }}' --target="${target}" --no-default-features --features='${{ matrix.features }}'
             mv target/"${target}"/'${{ matrix.profile }}/${{ env.cargo_build_binary_name }}${{ matrix.binary_ext }}' tmp/binary/"${target}"'${{ matrix.binary_ext }}'
           done
 

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -31,7 +31,6 @@
             "args": [
                 "run",
                 "--release",
-                "--no-default-features"
             ],
             "presentation": {
                 "clear": true
@@ -48,7 +47,6 @@
             "args": [
                 "run",
                 "--yes",
-                "--no-default-features",
                 "web"
             ],
             "options": {
@@ -72,7 +70,6 @@
                 "run",
                 "--yes",
                 "--release",
-                "--no-default-features",
                 "web"
             ],
             "presentation": {

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,16 @@ dev_native = [
 ]
 
 
+[package.metadata.bevy_cli.release]
+# Disable debug functionality in release builds
+default_features = false
+
+[package.metadata.bevy_cli.web.dev]
+# Disable native-only debug functionality in web builds
+default_features = false
+features = ["dev"]
+
+
 [lints.clippy]
 # Bevy supplies arguments to systems via dependency injection, so it's natural for systems to
 # request more than 7 arguments, which would undesirably trigger this lint.

--- a/Cargo.toml.template
+++ b/Cargo.toml.template
@@ -38,6 +38,16 @@ dev_native = [
 ]
 
 
+[package.metadata.bevy_cli.release]
+# Disable debug functionality in release builds
+default_features = false
+
+[package.metadata.bevy_cli.web.dev]
+# Disable native-only debug functionality in web builds
+default_features = false
+features = ["dev"]
+
+
 [lints.clippy]
 # Bevy supplies arguments to systems via dependency injection, so it's natural for systems to
 # request more than 7 arguments, which would undesirably trigger this lint.

--- a/README.md
+++ b/README.md
@@ -53,15 +53,15 @@ We recommend running your game with the [Bevy CLI](https://github.com/TheBevyFlo
 Running your game locally is very simple:
 
 - Use `bevy run` to run a native dev build.
-- Use `bevy run --no-default-features web` to run a web dev build.
+- Use `bevy run web` to run a web dev build.
 
 If you're using [VS Code](https://code.visualstudio.com/), this template comes with a [`.vscode/tasks.json`](./.vscode/tasks.json) file.
 
 <details>
   <summary>Run release builds</summary>
 
-- Use `bevy run --release --no-default-features` to run a native release build.
-- Use `bevy run --release --no-default-features web` to run a web release build.
+- Use `bevy run --release` to run a native release build.
+- Use `bevy run --release web` to run a web release build.
 
 </details>
 


### PR DESCRIPTION
# Objective

We enable some dev features by default which do not work on Wasm, such as the `file-watcher`.
This causes the need to always add `--no-default-features` when running `bevy run web`.
Similarly, for release builds we also need to disable the dev features, also requiring `--no-default-features`.

Ideally, it should be possible to just use `bevy run web` and `bevy run --release` and having the features toggled automatically.

# Solution

With <https://github.com/TheBevyFlock/bevy_cli/pull/331> we can define features or disable default features for dev/release and native/web builds.

This can be used to simplify the `web` and `release` commands.

# Testing

- Install the latest version of Bevy CLI:
    ```
    cargo install --git https://github.com/TheBevyFlock/bevy_cli --force --locked bevy_cli
    ```
- Use e.g. `bevy run web` (previously you needed `bevy run --no-default-features web` or you'd get a compile error)
- Tip: Add the `--verbose` flag to see which commands the CLI is running, to verify that the correct features are enabled