### PR TITLE
Revert "Add config to fix default web and release builds (#357)"

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -196,7 +196,7 @@ jobs:
         if: ${{ env.is_platform_enabled == 'true' && matrix.platform == 'web' }}
         run: |
           cargo install --git=https://github.com/TheBevyFlock/bevy_cli --locked bevy_cli
-          bevy build --locked --profile='${{ matrix.profile }}' --features='${{ matrix.features }}' --yes web --bundle
+          bevy build --locked --profile='${{ matrix.profile }}' --no-default-features --features='${{ matrix.features }}' --yes web --bundle
 
       - name: Add web bundle to app (Web)
         if: ${{ env.is_platform_enabled == 'true' && matrix.platform == 'web' }}

--- a/.github/workflows/release.yaml.template
+++ b/.github/workflows/release.yaml.template
@@ -205,7 +205,7 @@ jobs:
         if: ${{ env.is_platform_enabled == 'true' && matrix.platform == 'web' }}
         run: |
           cargo install --git=https://github.com/TheBevyFlock/bevy_cli --locked bevy_cli
-          bevy build --locked --profile='${{ matrix.profile }}' --features='${{ matrix.features }}' --yes web --bundle
+          bevy build --locked --profile='${{ matrix.profile }}' --no-default-features --features='${{ matrix.features }}' --yes web --bundle
 
       - name: Add web bundle to app (Web)
         if: ${{ env.is_platform_enabled == 'true' && matrix.platform == 'web' }}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -31,6 +31,7 @@
             "args": [
                 "run",
                 "--release",
+                "--no-default-features"
             ],
             "presentation": {
                 "clear": true
@@ -47,6 +48,7 @@
             "args": [
                 "run",
                 "--yes",
+                "--no-default-features",
                 "web"
             ],
             "options": {
@@ -70,6 +72,7 @@
                 "run",
                 "--yes",
                 "--release",
+                "--no-default-features",
                 "web"
             ],
             "presentation": {

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,16 +38,6 @@ dev_native = [
 ]
 
 
-[package.metadata.bevy_cli.release]
-# Disable debug functionality in release builds
-default_features = false
-
-[package.metadata.bevy_cli.web.dev]
-# Disable native-only debug functionality in web builds
-default_features = false
-features = ["dev"]
-
-
 [lints.clippy]
 # Bevy supplies arguments to systems via dependency injection, so it's natural for systems to
 # request more than 7 arguments, which would undesirably trigger this lint.

--- a/Cargo.toml.template
+++ b/Cargo.toml.template
@@ -38,16 +38,6 @@ dev_native = [
 ]
 
 
-[package.metadata.bevy_cli.release]
-# Disable debug functionality in release builds
-default_features = false
-
-[package.metadata.bevy_cli.web.dev]
-# Disable native-only debug functionality in web builds
-default_features = false
-features = ["dev"]
-
-
 [lints.clippy]
 # Bevy supplies arguments to systems via dependency injection, so it's natural for systems to
 # request more than 7 arguments, which would undesirably trigger this lint.

--- a/README.md
+++ b/README.md
@@ -53,15 +53,15 @@ We recommend running your game with the [Bevy CLI](https://github.com/TheBevyFlo
 Running your game locally is very simple:
 
 - Use `bevy run` to run a native dev build.
-- Use `bevy run web` to run a web dev build.
+- Use `bevy run --no-default-features web` to run a web dev build.
 
 If you're using [VS Code](https://code.visualstudio.com/), this template comes with a [`.vscode/tasks.json`](./.vscode/tasks.json) file.
 
 <details>
   <summary>Run release builds</summary>
 
-- Use `bevy run --release` to run a native release build.
-- Use `bevy run --release web` to run a web release build.
+- Use `bevy run --release --no-default-features` to run a native release build.
+- Use `bevy run --release --no-default-features web` to run a web release build.
 
 </details>
 


### PR DESCRIPTION
This reverts commit dfbdbcbc3f373068d21f44e0cf73001462e8a019.
Otherwise, `bevy build` doesn't use the `dev_native` feature due to https://github.com/TheBevyFlock/bevy_cli/issues/370