### PR TITLE
Trigger buttons on click, not on release

### DIFF
--- a/src/screens/credits.rs
+++ b/src/screens/credits.rs
@@ -79,7 +79,7 @@ fn grid(content: Vec<[&'static str; 2]>) -> impl Bundle {
     )
 }
 
-fn enter_title_screen(_: Trigger<Pointer<Released>>, mut next_screen: ResMut<NextState<Screen>>) {
+fn enter_title_screen(_: Trigger<Pointer<Click>>, mut next_screen: ResMut<NextState<Screen>>) {
     next_screen.set(Screen::Title);
 }
 

--- a/src/screens/title.rs
+++ b/src/screens/title.rs
@@ -24,18 +24,15 @@ fn spawn_title_screen(mut commands: Commands) {
         });
 }
 
-fn enter_gameplay_screen(
-    _: Trigger<Pointer<Released>>,
-    mut next_screen: ResMut<NextState<Screen>>,
-) {
+fn enter_gameplay_screen(_: Trigger<Pointer<Click>>, mut next_screen: ResMut<NextState<Screen>>) {
     next_screen.set(Screen::Gameplay);
 }
 
-fn enter_credits_screen(_: Trigger<Pointer<Released>>, mut next_screen: ResMut<NextState<Screen>>) {
+fn enter_credits_screen(_: Trigger<Pointer<Click>>, mut next_screen: ResMut<NextState<Screen>>) {
     next_screen.set(Screen::Credits);
 }
 
 #[cfg(not(target_family = "wasm"))]
-fn exit_app(_: Trigger<Pointer<Released>>, mut app_exit: EventWriter<AppExit>) {
+fn exit_app(_: Trigger<Pointer<Click>>, mut app_exit: EventWriter<AppExit>) {
     app_exit.write(AppExit::Success);
 }

--- a/src/theme/widget.rs
+++ b/src/theme/widget.rs
@@ -25,7 +25,7 @@ pub fn ui_root(name: impl Into<Cow<'static, str>>) -> impl Bundle {
 
 /// A simple button with text.
 ///
-/// Add a [`Pointer<Released>`] observer to the button to make it do something on click.
+/// Add a [`Pointer<Click>`] observer to the button to make it do something on click.
 pub fn button(text: impl Into<String>) -> impl Bundle {
     (
         Name::new("Button"),


### PR DESCRIPTION
Using `Pointer<Released>` means that if a user presses down on empty space, then moves the cursor over a button and releases, the button's action will trigger. Instead, we should require the user to press down _on the button_ before releasing over the button, which is how `Pointer<Click>` behaves.