### PR TITLE
Some style changes

### DIFF
--- a/src/audio.rs
+++ b/src/audio.rs
@@ -1,37 +1,25 @@
 use bevy::prelude::*;
 
-/// An organizational marker component that should be added to a spawned [`AudioPlayer`] if it is in the
-/// general "music" category (ex: global background music, soundtrack, etc).
+/// An organizational marker component that should be added to a spawned [`AudioPlayer`] if it's in the
+/// general "music" category (e.g. global background music, soundtrack).
 ///
-/// This can then be used to query for and operate on sounds in that category. For example:
-///
-/// ```
-/// use bevy::{audio::Volume, prelude::*};
-/// use bevy_new_2d::audio::Music;
-///
-/// fn set_music_volume(mut sink_query: Query<&mut AudioSink, With<Music>>) {
-///     for mut sink in &mut sink_query {
-///         sink.set_volume(Volume::Linear(0.5));
-///     }
-/// }
-/// ```
+/// This can then be used to query for and operate on sounds in that category.
 #[derive(Component, Default)]
 pub struct Music;
 
-/// An organizational marker component that should be added to a spawned [`AudioPlayer`] if it is in the
-/// general "sound effect" category (ex: footsteps, the sound of a magic spell, a door opening).
+/// A music audio instance.
+pub fn music(handle: Handle<AudioSource>) -> impl Bundle {
+    (AudioPlayer(handle), PlaybackSettings::LOOP, Music)
+}
+
+/// An organizational marker component that should be added to a spawned [`AudioPlayer`] if it's in the
+/// general "sound effect" category (e.g. footsteps, the sound of a magic spell, a door opening).
 ///
-/// This can then be used to query for and operate on sounds in that category. For example:
-///
-/// ```
-/// use bevy::{audio::Volume, prelude::*};
-/// use bevy_new_2d::audio::SoundEffect;
-///
-/// fn set_sound_effect_volume(mut sink_query: Query<&mut AudioSink, With<SoundEffect>>) {
-///     for mut sink in &mut sink_query {
-///         sink.set_volume(Volume::Linear(0.5));
-///     }
-/// }
-/// ```
+/// This can then be used to query for and operate on sounds in that category.
 #[derive(Component, Default)]
 pub struct SoundEffect;
+
+/// A sound effect audio instance.
+pub fn sound_effect(handle: Handle<AudioSource>) -> impl Bundle {
+    (AudioPlayer(handle), PlaybackSettings::DESPAWN, SoundEffect)
+}

--- a/src/audio.rs.template
+++ b/src/audio.rs.template
@@ -1,37 +1,25 @@
 use bevy::prelude::*;
 
-/// An organizational marker component that should be added to a spawned [`AudioPlayer`] if it is in the
-/// general "music" category (ex: global background music, soundtrack, etc).
+/// An organizational marker component that should be added to a spawned [`AudioPlayer`] if it's in the
+/// general "music" category (e.g. global background music, soundtrack).
 ///
-/// This can then be used to query for and operate on sounds in that category. For example:
-///
-/// ```
-/// use bevy::{audio::Volume, prelude::*};
-/// use {{crate_name}}::audio::Music;
-///
-/// fn set_music_volume(mut sink_query: Query<&mut AudioSink, With<Music>>) {
-///     for mut sink in &mut sink_query {
-///         sink.set_volume(Volume::Linear(0.5));
-///     }
-/// }
-/// ```
+/// This can then be used to query for and operate on sounds in that category.
 #[derive(Component, Default)]
 pub struct Music;
 
-/// An organizational marker component that should be added to a spawned [`AudioPlayer`] if it is in the
-/// general "sound effect" category (ex: footsteps, the sound of a magic spell, a door opening).
+/// A music audio instance.
+pub fn music(handle: Handle<AudioSource>) -> impl Bundle {
+    (AudioPlayer(handle), PlaybackSettings::LOOP, Music)
+}
+
+/// An organizational marker component that should be added to a spawned [`AudioPlayer`] if it's in the
+/// general "sound effect" category (e.g. footsteps, the sound of a magic spell, a door opening).
 ///
-/// This can then be used to query for and operate on sounds in that category. For example:
-///
-/// ```
-/// use bevy::{audio::Volume, prelude::*};
-/// use {{crate_name}}::audio::SoundEffect;
-///
-/// fn set_sound_effect_volume(mut sink_query: Query<&mut AudioSink, With<SoundEffect>>) {
-///     for mut sink in &mut sink_query {
-///         sink.set_volume(Volume::Linear(0.5));
-///     }
-/// }
-/// ```
+/// This can then be used to query for and operate on sounds in that category.
 #[derive(Component, Default)]
 pub struct SoundEffect;
+
+/// A sound effect audio instance.
+pub fn sound_effect(handle: Handle<AudioSource>) -> impl Bundle {
+    (AudioPlayer(handle), PlaybackSettings::DESPAWN, SoundEffect)
+}

--- a/src/demo/animation.rs
+++ b/src/demo/animation.rs
@@ -10,7 +10,7 @@ use std::time::Duration;
 
 use crate::{
     AppSet,
-    audio::SoundEffect,
+    audio::sound_effect,
     demo::{movement::MovementController, player::PlayerAssets},
 };
 
@@ -84,12 +84,8 @@ fn trigger_step_sound_effect(
             && (animation.frame == 2 || animation.frame == 5)
         {
             let rng = &mut rand::thread_rng();
-            let random_step = player_assets.steps.choose(rng).unwrap();
-            commands.spawn((
-                AudioPlayer(random_step.clone()),
-                PlaybackSettings::DESPAWN,
-                SoundEffect,
-            ));
+            let random_step = player_assets.steps.choose(rng).unwrap().clone();
+            commands.spawn(sound_effect(random_step));
         }
     }
 }

--- a/src/demo/movement.rs
+++ b/src/demo/movement.rs
@@ -18,7 +18,8 @@ use bevy::{prelude::*, window::PrimaryWindow};
 use crate::AppSet;
 
 pub(super) fn plugin(app: &mut App) {
-    app.register_type::<(MovementController, ScreenWrap)>();
+    app.register_type::<MovementController>();
+    app.register_type::<ScreenWrap>();
 
     app.add_systems(
         Update,
@@ -38,8 +39,7 @@ pub struct MovementController {
     pub intent: Vec2,
 
     /// Maximum speed in world units per second.
-    /// 1 world unit = 1 pixel when using the default 2D camera and no physics
-    /// engine.
+    /// 1 world unit = 1 pixel when using the default 2D camera and no physics engine.
     pub max_speed: f32,
 }
 
@@ -68,12 +68,9 @@ fn apply_movement(
 pub struct ScreenWrap;
 
 fn apply_screen_wrap(
-    window_query: Query<&Window, With<PrimaryWindow>>,
+    window: Single<&Window, With<PrimaryWindow>>,
     mut wrap_query: Query<&mut Transform, With<ScreenWrap>>,
 ) {
-    let Ok(window) = window_query.single() else {
-        return;
-    };
     let size = window.size() + 256.0;
     let half_size = size / 2.0;
     for mut transform in &mut wrap_query {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,5 @@
 mod asset_tracking;
-pub mod audio;
+mod audio;
 mod demo;
 #[cfg(feature = "dev")]
 mod dev_tools;

--- a/src/lib.rs.template
+++ b/src/lib.rs.template
@@ -1,5 +1,5 @@
 mod asset_tracking;
-pub mod audio;
+mod audio;
 mod demo;
 #[cfg(feature = "dev")]
 mod dev_tools;

--- a/src/screens/credits.rs
+++ b/src/screens/credits.rs
@@ -2,7 +2,7 @@
 
 use bevy::{ecs::spawn::SpawnIter, prelude::*, ui::Val::*};
 
-use crate::{asset_tracking::LoadResource, audio::Music, screens::Screen, theme::prelude::*};
+use crate::{asset_tracking::LoadResource, audio::music, screens::Screen, theme::prelude::*};
 
 pub(super) fn plugin(app: &mut App) {
     app.add_systems(OnEnter(Screen::Credits), spawn_credits_screen);
@@ -82,7 +82,7 @@ fn enter_title_screen(_: Trigger<Pointer<Click>>, mut next_screen: ResMut<NextSt
 #[reflect(Resource)]
 struct CreditsMusic {
     #[dependency]
-    music: Handle<AudioSource>,
+    handle: Handle<AudioSource>,
     entity: Option<Entity>,
 }
 
@@ -90,26 +90,18 @@ impl FromWorld for CreditsMusic {
     fn from_world(world: &mut World) -> Self {
         let assets = world.resource::<AssetServer>();
         Self {
-            music: assets.load("audio/music/Monkeys Spinning Monkeys.ogg"),
+            handle: assets.load("audio/music/Monkeys Spinning Monkeys.ogg"),
             entity: None,
         }
     }
 }
 
-fn start_credits_music(mut commands: Commands, mut music: ResMut<CreditsMusic>) {
-    music.entity = Some(
-        commands
-            .spawn((
-                AudioPlayer(music.music.clone()),
-                PlaybackSettings::LOOP,
-                Music,
-            ))
-            .id(),
-    );
+fn start_credits_music(mut commands: Commands, mut credits_music: ResMut<CreditsMusic>) {
+    credits_music.entity = Some(commands.spawn(music(credits_music.handle.clone())).id());
 }
 
-fn stop_credits_music(mut commands: Commands, mut music: ResMut<CreditsMusic>) {
-    if let Some(entity) = music.entity.take() {
+fn stop_credits_music(mut commands: Commands, mut credits_music: ResMut<CreditsMusic>) {
+    if let Some(entity) = credits_music.entity.take() {
         commands.entity(entity).despawn();
     }
 }

--- a/src/screens/credits.rs
+++ b/src/screens/credits.rs
@@ -97,7 +97,8 @@ impl FromWorld for CreditsMusic {
 }
 
 fn start_credits_music(mut commands: Commands, mut credits_music: ResMut<CreditsMusic>) {
-    credits_music.entity = Some(commands.spawn(music(credits_music.handle.clone())).id());
+    let handle = credits_music.handle.clone();
+    credits_music.entity = Some(commands.spawn(music(handle)).id());
 }
 
 fn stop_credits_music(mut commands: Commands, mut credits_music: ResMut<CreditsMusic>) {

--- a/src/screens/gameplay.rs
+++ b/src/screens/gameplay.rs
@@ -45,7 +45,8 @@ impl FromWorld for GameplayMusic {
 }
 
 fn start_gameplay_music(mut commands: Commands, mut gameplay_music: ResMut<GameplayMusic>) {
-    gameplay_music.entity = Some(commands.spawn(music(gameplay_music.handle.clone())).id());
+    let handle = gameplay_music.handle.clone();
+    gameplay_music.entity = Some(commands.spawn(music(handle)).id());
 }
 
 fn stop_gameplay_music(mut commands: Commands, mut gameplay_music: ResMut<GameplayMusic>) {

--- a/src/screens/gameplay.rs
+++ b/src/screens/gameplay.rs
@@ -3,7 +3,7 @@
 use bevy::{input::common_conditions::input_just_pressed, prelude::*};
 
 use crate::{
-    asset_tracking::LoadResource, audio::Music, demo::level::spawn_level as spawn_level_command,
+    asset_tracking::LoadResource, audio::music, demo::level::spawn_level as spawn_level_command,
     screens::Screen,
 };
 
@@ -30,7 +30,7 @@ fn spawn_level(mut commands: Commands) {
 #[reflect(Resource)]
 struct GameplayMusic {
     #[dependency]
-    music: Handle<AudioSource>,
+    handle: Handle<AudioSource>,
     entity: Option<Entity>,
 }
 
@@ -38,26 +38,18 @@ impl FromWorld for GameplayMusic {
     fn from_world(world: &mut World) -> Self {
         let assets = world.resource::<AssetServer>();
         Self {
-            music: assets.load("audio/music/Fluffing A Duck.ogg"),
+            handle: assets.load("audio/music/Fluffing A Duck.ogg"),
             entity: None,
         }
     }
 }
 
-fn start_gameplay_music(mut commands: Commands, mut music: ResMut<GameplayMusic>) {
-    music.entity = Some(
-        commands
-            .spawn((
-                AudioPlayer(music.music.clone()),
-                PlaybackSettings::LOOP,
-                Music,
-            ))
-            .id(),
-    );
+fn start_gameplay_music(mut commands: Commands, mut gameplay_music: ResMut<GameplayMusic>) {
+    gameplay_music.entity = Some(commands.spawn(music(gameplay_music.handle.clone())).id());
 }
 
-fn stop_gameplay_music(mut commands: Commands, mut music: ResMut<GameplayMusic>) {
-    if let Some(entity) = music.entity.take() {
+fn stop_gameplay_music(mut commands: Commands, mut gameplay_music: ResMut<GameplayMusic>) {
+    if let Some(entity) = gameplay_music.entity.take() {
         commands.entity(entity).despawn();
     }
 }

--- a/src/theme/interaction.rs
+++ b/src/theme/interaction.rs
@@ -1,6 +1,6 @@
 use bevy::prelude::*;
 
-use crate::{asset_tracking::LoadResource, audio::SoundEffect};
+use crate::{asset_tracking::LoadResource, audio::sound_effect};
 
 pub(super) fn plugin(app: &mut App) {
     app.register_type::<InteractionPalette>();
@@ -72,6 +72,6 @@ fn trigger_interaction_sound_effect(
             Interaction::Pressed => interaction_assets.press.clone(),
             _ => continue,
         };
-        commands.spawn((AudioPlayer(source), PlaybackSettings::DESPAWN, SoundEffect));
+        commands.spawn(sound_effect(source));
     }
 }

--- a/src/theme/widget.rs
+++ b/src/theme/widget.rs
@@ -3,7 +3,7 @@
 use std::borrow::Cow;
 
 use bevy::{
-    ecs::{relationship::RelatedSpawner, spawn::SpawnWith, system::IntoObserverSystem},
+    ecs::{spawn::SpawnWith, system::IntoObserverSystem},
     prelude::*,
     ui::Val::*,
 };
@@ -52,13 +52,14 @@ pub fn button<E, B, M, I>(text: impl Into<String>, action: I) -> impl Bundle
 where
     E: Event,
     B: Bundle,
-    I: IntoObserverSystem<E, B, M> + Sync,
+    I: IntoObserverSystem<E, B, M>,
 {
     let text = text.into();
+    let action = IntoObserverSystem::into_system(action);
     (
         Name::new("Button"),
         Node::default(),
-        Children::spawn(SpawnWith(|parent: &mut RelatedSpawner<ChildOf>| {
+        Children::spawn(SpawnWith(|parent: &mut ChildSpawner| {
             parent
                 .spawn((
                     Name::new("Button Inner"),


### PR DESCRIPTION
Please let me know if you don't like any of these changes, because they're subjective.

Summary of changes:
- Simplify comments in `audio.rs` and add bundle functions for sfx/music
- Split a `register_type::<(...)>` (see [cart's reasoning on Discord](https://discord.com/channels/691052431525675048/1002362493634629796/1351279139872571462))
- Use `Single` where possible (only one place)
- Use the `ChildSpawner` type alias instead of `RelatedSpawner<ChildOf>`
- Remove `I: Sync` trait bound by calling `IntoObserverSystem::into_system(action)` outside of the closure

I also looked for any cases where we could use Bevy's new error handling with `-> Result`, but we don't seem to have any good use cases for it.