### PR TITLE
Move loading sync point to before gameplay

### DIFF
--- a/src/screens/loading.rs
+++ b/src/screens/loading.rs
@@ -10,7 +10,7 @@ pub(super) fn plugin(app: &mut App) {
 
     app.add_systems(
         Update,
-        continue_to_title_screen.run_if(in_state(Screen::Loading).and(all_assets_loaded)),
+        continue_to_gameplay_screen.run_if(in_state(Screen::Loading).and(all_assets_loaded)),
     );
 }
 
@@ -22,8 +22,8 @@ fn spawn_loading_screen(mut commands: Commands) {
     ));
 }
 
-fn continue_to_title_screen(mut next_screen: ResMut<NextState<Screen>>) {
-    next_screen.set(Screen::Title);
+fn continue_to_gameplay_screen(mut next_screen: ResMut<NextState<Screen>>) {
+    next_screen.set(Screen::Gameplay);
 }
 
 fn all_assets_loaded(resource_handles: Res<ResourceHandles>) -> bool {

--- a/src/screens/loading.rs
+++ b/src/screens/loading.rs
@@ -6,10 +6,7 @@ use bevy::prelude::*;
 use crate::{asset_tracking::ResourceHandles, screens::Screen, theme::prelude::*};
 
 pub(super) fn plugin(app: &mut App) {
-    app.add_systems(
-        OnEnter(Screen::Loading),
-        spawn_loading_screen.run_if(not(all_assets_loaded)),
-    );
+    app.add_systems(OnEnter(Screen::Loading), spawn_loading_screen);
 
     app.add_systems(
         Update,

--- a/src/screens/loading.rs
+++ b/src/screens/loading.rs
@@ -6,7 +6,10 @@ use bevy::prelude::*;
 use crate::{asset_tracking::ResourceHandles, screens::Screen, theme::prelude::*};
 
 pub(super) fn plugin(app: &mut App) {
-    app.add_systems(OnEnter(Screen::Loading), spawn_loading_screen);
+    app.add_systems(
+        OnEnter(Screen::Loading),
+        spawn_loading_screen.run_if(not(all_assets_loaded)),
+    );
 
     app.add_systems(
         Update,

--- a/src/screens/mod.rs
+++ b/src/screens/mod.rs
@@ -26,8 +26,8 @@ pub(super) fn plugin(app: &mut App) {
 pub enum Screen {
     #[default]
     Splash,
-    Loading,
     Title,
     Credits,
+    Loading,
     Gameplay,
 }

--- a/src/screens/splash.rs
+++ b/src/screens/splash.rs
@@ -39,7 +39,7 @@ pub(super) fn plugin(app: &mut App) {
     // Exit the splash screen early if the player hits escape.
     app.add_systems(
         Update,
-        continue_to_loading_screen
+        continue_to_title_screen
             .run_if(input_just_pressed(KeyCode::Escape).and(in_state(Screen::Splash))),
     );
 }
@@ -137,10 +137,10 @@ fn tick_splash_timer(time: Res<Time>, mut timer: ResMut<SplashTimer>) {
 
 fn check_splash_timer(timer: ResMut<SplashTimer>, mut next_screen: ResMut<NextState<Screen>>) {
     if timer.0.just_finished() {
-        next_screen.set(Screen::Loading);
+        next_screen.set(Screen::Title);
     }
 }
 
-fn continue_to_loading_screen(mut next_screen: ResMut<NextState<Screen>>) {
-    next_screen.set(Screen::Loading);
+fn continue_to_title_screen(mut next_screen: ResMut<NextState<Screen>>) {
+    next_screen.set(Screen::Title);
 }

--- a/src/screens/title.rs
+++ b/src/screens/title.rs
@@ -13,7 +13,7 @@ fn spawn_title_screen(mut commands: Commands) {
         widget::ui_root("Title Screen"),
         StateScoped(Screen::Title),
         children![
-            widget::button("Play", enter_gameplay_screen),
+            widget::button("Play", enter_loading_screen),
             widget::button("Credits", enter_credits_screen),
             #[cfg(not(target_family = "wasm"))]
             widget::button("Exit", exit_app),
@@ -21,8 +21,8 @@ fn spawn_title_screen(mut commands: Commands) {
     ));
 }
 
-fn enter_gameplay_screen(_: Trigger<Pointer<Click>>, mut next_screen: ResMut<NextState<Screen>>) {
-    next_screen.set(Screen::Gameplay);
+fn enter_loading_screen(_: Trigger<Pointer<Click>>, mut next_screen: ResMut<NextState<Screen>>) {
+    next_screen.set(Screen::Loading);
 }
 
 fn enter_credits_screen(_: Trigger<Pointer<Click>>, mut next_screen: ResMut<NextState<Screen>>) {

--- a/src/screens/title.rs
+++ b/src/screens/title.rs
@@ -2,7 +2,7 @@
 
 use bevy::prelude::*;
 
-use crate::{screens::Screen, theme::prelude::*};
+use crate::{asset_tracking::ResourceHandles, screens::Screen, theme::prelude::*};
 
 pub(super) fn plugin(app: &mut App) {
     app.add_systems(OnEnter(Screen::Title), spawn_title_screen);
@@ -21,8 +21,16 @@ fn spawn_title_screen(mut commands: Commands) {
     ));
 }
 
-fn enter_loading_screen(_: Trigger<Pointer<Click>>, mut next_screen: ResMut<NextState<Screen>>) {
-    next_screen.set(Screen::Loading);
+fn enter_loading_screen(
+    _: Trigger<Pointer<Click>>,
+    resource_handles: Res<ResourceHandles>,
+    mut next_screen: ResMut<NextState<Screen>>,
+) {
+    if resource_handles.is_all_done() {
+        next_screen.set(Screen::Gameplay);
+    } else {
+        next_screen.set(Screen::Loading);
+    }
 }
 
 fn enter_credits_screen(_: Trigger<Pointer<Click>>, mut next_screen: ResMut<NextState<Screen>>) {


### PR DESCRIPTION
- This way, assets can load during the splash screen and title menu.
- Restarting the app will lead to visiting the loading state multiple times, but the UI will only show when actually loading anything
- We didn't preload the splash image before and are still not doing that because I'd prefer to [just use embedded_asset](https://github.com/bevyengine/bevy/issues/14246) once it works on all platforms
