### PR TITLE
Switch to `Swatinem/rust-cache`

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,9 +28,7 @@ jobs:
         run: sudo apt-get update; sudo apt-get install --no-install-recommends libasound2-dev libudev-dev libwayland-dev libxkbcommon-dev
 
       - name: Populate target directory from cache
-        uses: Leafwing-Studios/cargo-cache@v2
-        with:
-          sweep-cache: true
+        uses: Swatinem/rust-cache@v2
 
       - name: Run tests
         run: |
@@ -57,9 +55,7 @@ jobs:
         run: sudo apt-get update; sudo apt-get install --no-install-recommends libasound2-dev libudev-dev libwayland-dev libxkbcommon-dev
 
       - name: Populate target directory from cache
-        uses: Leafwing-Studios/cargo-cache@v2
-        with:
-          sweep-cache: true
+        uses: Swatinem/rust-cache@v2
 
       - name: Install Bevy CLI
         run: cargo install --git=https://github.com/TheBevyFlock/bevy_cli --locked bevy_cli
@@ -86,9 +82,7 @@ jobs:
         run: sudo apt-get update; sudo apt-get install --no-install-recommends libasound2-dev libudev-dev libwayland-dev libxkbcommon-dev
 
       - name: Populate target directory from cache
-        uses: Leafwing-Studios/cargo-cache@v2
-        with:
-          sweep-cache: true
+        uses: Swatinem/rust-cache@v2
 
       - name: Run clippy lints
         run: cargo clippy --locked --workspace --all-targets --all-features -- --deny warnings
@@ -126,9 +120,7 @@ jobs:
         run: sudo apt-get update; sudo apt-get install --no-install-recommends libasound2-dev libudev-dev libwayland-dev libxkbcommon-dev
 
       - name: Populate target directory from cache
-        uses: Leafwing-Studios/cargo-cache@v2
-        with:
-          sweep-cache: true
+        uses: Swatinem/rust-cache@v2
 
       - name: Check documentation
         run: cargo doc --locked --workspace --all-features --document-private-items --no-deps

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -29,6 +29,8 @@ jobs:
 
       - name: Populate target directory from cache
         uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Run tests
         run: |
@@ -56,6 +58,8 @@ jobs:
 
       - name: Populate target directory from cache
         uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Install Bevy CLI
         run: cargo install --git=https://github.com/TheBevyFlock/bevy_cli --locked bevy_cli
@@ -83,6 +87,8 @@ jobs:
 
       - name: Populate target directory from cache
         uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Run clippy lints
         run: cargo clippy --locked --workspace --all-targets --all-features -- --deny warnings
@@ -121,6 +127,8 @@ jobs:
 
       - name: Populate target directory from cache
         uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Check documentation
         run: cargo doc --locked --workspace --all-features --document-private-items --no-deps

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -181,6 +181,8 @@ jobs:
       - name: Populate cargo cache
         if: ${{ env.is_platform_enabled == 'true' && env.use_github_cache == 'true' }}
         uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Install dependencies (Linux)
         if: ${{ env.is_platform_enabled == 'true' && matrix.platform == 'linux' }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -180,9 +180,7 @@ jobs:
 
       - name: Populate cargo cache
         if: ${{ env.is_platform_enabled == 'true' && env.use_github_cache == 'true' }}
-        uses: Leafwing-Studios/cargo-cache@v2
-        with:
-          sweep-cache: true
+        uses: Swatinem/rust-cache@v2
 
       - name: Install dependencies (Linux)
         if: ${{ env.is_platform_enabled == 'true' && matrix.platform == 'linux' }}

--- a/.github/workflows/release.yaml.template
+++ b/.github/workflows/release.yaml.template
@@ -190,6 +190,8 @@ jobs:
       - name: Populate cargo cache
         if: ${{ env.is_platform_enabled == 'true' && env.use_github_cache == 'true' }}
         uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Install dependencies (Linux)
         if: ${{ env.is_platform_enabled == 'true' && matrix.platform == 'linux' }}

--- a/.github/workflows/release.yaml.template
+++ b/.github/workflows/release.yaml.template
@@ -189,9 +189,7 @@ jobs:
 
       - name: Populate cargo cache
         if: ${{ env.is_platform_enabled == 'true' && env.use_github_cache == 'true' }}
-        uses: Leafwing-Studios/cargo-cache@v2
-        with:
-          sweep-cache: true
+        uses: Swatinem/rust-cache@v2
 
       - name: Install dependencies (Linux)
         if: ${{ env.is_platform_enabled == 'true' && matrix.platform == 'linux' }}


### PR DESCRIPTION
From https://github.com/TheBevyFlock/bevy_new_2d/issues/377#issuecomment-2835276190:

> I think it may be worth switching to [`Swatinem/rust-cache`](https://github.com/Swatinem/rust-cache) instead. It's [used by the Rust project](https://github.com/search?q=repo%3Arust-lang%2Frust+%22Swatinem%2Frust-cache%22+language%3AYAML&type=code) and provides more features than `Leafwing-Studios/cargo-cache`. Its strategy of only caching dependencies, disabling incremental compilation, and cleaning files over a week old is likely better than what we're currently doing.

This PR is a test to see how `Swatinem/rust-cache` performs in CI, and whether it is better than `Leafwing-Studios/cargo-cache` in practice or not. Note that we can [make the cache only save when run on `main`](https://github.com/Swatinem/rust-cache/blob/9d47c6ad4b02e050fd481d890b2ea34778fd09d6/README.md?plain=1#L69-L70), which should avoid creating needless caches [that cannot be used](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/caching-dependencies-to-speed-up-workflows#restrictions-for-accessing-a-cache).