### PR TITLE
Make web builds more robust

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,10 @@ dev_native = [
 # Disable debug functionality in release builds.
 default_features = false
 
+[package.metadata.bevy_cli.web]
+# Tell the random providing crates to use the wasm_js backend on Web.
+rustflags = ["--cfg", "getrandom_backend=\"wasm_js\""]
+
 [package.metadata.bevy_cli.web.dev]
 # Disable native-only debug functionality in web builds.
 default_features = false


### PR DESCRIPTION
Otherwise, we might get this:

![image](https://github.com/user-attachments/assets/6a4106dd-63bf-4840-a11b-fdc7eeaca8ff)


This error started cropping up in my 0.16 upgrades, dunno why. It happens on specific uses of `rand`, including through dependencies, so this might be very subtle for a user, especially since the error message is less then helpful.

Let's just remove that potential footgun :) I don't know how this interacts with the `RUSTFLAGS` env var that treats warnings as errors, but since we currently only run tests on native anyways, I figured it's alright.