### PR TITLE
Use `process` instead of `shell`

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -3,10 +3,10 @@
     "tasks": [
         {
             "label": "Run native dev",
-            "type": "shell",
+            "type": "process",
             "command": "bevy",
             "args": [
-                "run",
+                "run"
             ],
             "options": {
                 "env": {
@@ -26,11 +26,11 @@
         },
         {
             "label": "Run native release",
-            "type": "shell",
+            "type": "process",
             "command": "bevy",
             "args": [
                 "run",
-                "--release",
+                "--release"
             ],
             "presentation": {
                 "clear": true


### PR DESCRIPTION
We don't need any shell-specific features like glob, pipe, etc., we're just running a command with arguments, so we can use the simpler `"process"` task type.