### PR TITLE
Tweak workflow timeouts

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -98,7 +98,7 @@ jobs:
   format:
     name: Format
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 10
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,6 +17,7 @@ jobs:
   test:
     name: Tests
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -43,6 +44,7 @@ jobs:
   build-web:
     name: Build for web
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -71,6 +73,7 @@ jobs:
   clippy:
     name: Clippy
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -95,6 +98,7 @@ jobs:
   format:
     name: Format
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -111,6 +115,7 @@ jobs:
   doc:
     name: Docs
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -133,6 +138,7 @@ jobs:
   bevy-lint:
     name: Bevy linter
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,13 +10,13 @@ env:
   CARGO_TERM_COLOR: always
   RUSTFLAGS: --deny warnings
   RUSTDOCFLAGS: --deny warnings
+  LINTER_TOOLCHAIN: nightly-2025-04-03
 
 jobs:
   # Run tests.
   test:
     name: Tests
     runs-on: ubuntu-latest
-    timeout-minutes: 30
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -43,7 +43,6 @@ jobs:
   build-web:
     name: Build for web
     runs-on: ubuntu-latest
-    timeout-minutes: 30
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -72,7 +71,6 @@ jobs:
   clippy:
     name: Clippy
     runs-on: ubuntu-latest
-    timeout-minutes: 30
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -97,7 +95,6 @@ jobs:
   format:
     name: Format
     runs-on: ubuntu-latest
-    timeout-minutes: 30
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -114,7 +111,6 @@ jobs:
   doc:
     name: Docs
     runs-on: ubuntu-latest
-    timeout-minutes: 30
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -137,9 +133,6 @@ jobs:
   bevy-lint:
     name: Bevy linter
     runs-on: ubuntu-latest
-    timeout-minutes: 30
-    env:
-      LINTER_TOOLCHAIN: nightly-2025-04-03
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -156,6 +149,4 @@ jobs:
         uses: TheBevyFlock/bevy_cli/bevy_lint@lint-v0.3.0
 
       - name: Run Bevy linter
-        env:
-          RUSTFLAGS: --deny warnings
         run: bevy_lint --locked --workspace --all-targets --all-features


### PR DESCRIPTION
The first cacheless run can often take longer than 30 mins according to reports on discord.
I also moved the env vars together :)

Note that I'm experimenting with using a single shared key for the cache in Foxtrot, I'll report back on how well that works.