### PR TITLE
Reduce workflow cache size

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,7 +8,7 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
-  RUSTFLAGS: --deny warnings
+  RUSTFLAGS: --deny warnings -C debuginfo=1
   RUSTDOCFLAGS: --deny warnings
   LINTER_TOOLCHAIN: nightly-2025-04-03
 
@@ -28,17 +28,18 @@ jobs:
       - name: Install dependencies
         run: sudo apt-get update; sudo apt-get install --no-install-recommends libasound2-dev libudev-dev libwayland-dev libxkbcommon-dev
 
-      - name: Populate target directory from cache
+      - name: Restore Rust cache
         uses: Swatinem/rust-cache@v2
         with:
           save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Run tests
-        run: |
-          cargo test --locked --workspace --all-features --all-targets
-          # Running doc tests separately is a workaround for https://github.com/rust-lang/cargo/issues/6669
-          # Setting LD_LIBRARY_PATH is a workaround for https://github.com/TheBevyFlock/bevy_new_2d/pull/318#issuecomment-2585935350
-          LD_LIBRARY_PATH="$(rustc --print target-libdir)" cargo test --locked --workspace --all-features --doc
+        run: cargo test --locked --workspace --all-features --all-targets
+
+      # Running doc tests separately is a workaround for <https://github.com/rust-lang/cargo/issues/6669>.
+      - name: Run doctests
+        # Setting LD_LIBRARY_PATH is a workaround for <https://github.com/TheBevyFlock/bevy_new_2d/pull/318#issuecomment-2585935350>.
+        run: LD_LIBRARY_PATH="$(rustc --print target-libdir)" cargo test --locked --workspace --all-features --doc
 
   # Check that the game builds for web.
   build-web:
@@ -57,17 +58,16 @@ jobs:
       - name: Install dependencies
         run: sudo apt-get update; sudo apt-get install --no-install-recommends libasound2-dev libudev-dev libwayland-dev libxkbcommon-dev
 
-      - name: Populate target directory from cache
+      - name: Restore Rust cache
         uses: Swatinem/rust-cache@v2
         with:
           save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Install Bevy CLI
-        run: cargo install --git=https://github.com/TheBevyFlock/bevy_cli --locked bevy_cli
+        run: cargo install --git='https://github.com/TheBevyFlock/bevy_cli' --locked bevy_cli
 
       - name: Build for web
-        run: |
-          bevy build --locked --workspace --all-targets --yes web
+        run: bevy build --locked --workspace --all-targets --yes web
 
   # Run clippy lints.
   clippy:
@@ -86,13 +86,13 @@ jobs:
       - name: Install dependencies
         run: sudo apt-get update; sudo apt-get install --no-install-recommends libasound2-dev libudev-dev libwayland-dev libxkbcommon-dev
 
-      - name: Populate target directory from cache
+      - name: Restore Rust cache
         uses: Swatinem/rust-cache@v2
         with:
           save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Run clippy lints
-        run: cargo clippy --locked --workspace --all-targets --all-features -- --deny warnings
+        run: cargo clippy --locked --workspace --all-targets --all-features --no-deps
 
   # Check formatting.
   format:
@@ -126,7 +126,7 @@ jobs:
       - name: Install dependencies
         run: sudo apt-get update; sudo apt-get install --no-install-recommends libasound2-dev libudev-dev libwayland-dev libxkbcommon-dev
 
-      - name: Populate target directory from cache
+      - name: Restore Rust cache
         uses: Swatinem/rust-cache@v2
         with:
           save-if: ${{ github.ref == 'refs/heads/main' }}
@@ -146,7 +146,7 @@ jobs:
       - name: Install dependencies
         run: sudo apt-get update; sudo apt-get install --no-install-recommends libasound2-dev libudev-dev libwayland-dev libxkbcommon-dev
 
-      - name: Populate target directory from cache
+      - name: Restore Rust cache
         uses: Swatinem/rust-cache@v2
         with:
           save-if: ${{ github.ref == 'refs/heads/main' }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -92,7 +92,7 @@ jobs:
           save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Run clippy lints
-        run: cargo clippy --locked --workspace --all-targets --all-features --no-deps
+        run: cargo clippy --locked --workspace --all-targets --all-features
 
   # Check formatting.
   format:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -173,7 +173,7 @@ jobs:
         with:
           targets: ${{ matrix.targets }}
 
-      - name: Populate cargo cache
+      - name: Restore Rust cache
         if: ${{ env.is_platform_enabled == 'true' && env.use_github_cache == 'true' }}
         uses: Swatinem/rust-cache@v2
         with:

--- a/.github/workflows/release.yaml.template
+++ b/.github/workflows/release.yaml.template
@@ -182,7 +182,7 @@ jobs:
         with:
           targets: ${{ matrix.targets }}
 
-      - name: Populate cargo cache
+      - name: Restore Rust cache
         if: ${{ env.is_platform_enabled == 'true' && env.use_github_cache == 'true' }}
         uses: Swatinem/rust-cache@v2
         with:


### PR DESCRIPTION
Passing `debuginfo=0` would reduce the cache size even further (order of ~200MB), but may remove some debug information we actually want in CI. To be on the safe side, this PR uses `debuginfo=1` which should still be a huge win.