### PR TITLE
Move level music to level

### DIFF
--- a/src/demo/level.rs
+++ b/src/demo/level.rs
@@ -42,12 +42,12 @@ pub fn spawn_level(
         Transform::default(),
         Visibility::default(),
         StateScoped(Screen::Gameplay),
-        children![player(400.0, &player_assets, &mut texture_atlas_layouts)],
-    ));
-
-    commands.spawn((
-        Name::new("Level Music"),
-        StateScoped(Screen::Gameplay),
-        music(level_assets.music.clone()),
+        children![
+            player(400.0, &player_assets, &mut texture_atlas_layouts),
+            (
+                Name::new("Gameplay Music"),
+                music(level_assets.music.clone())
+            )
+        ],
     ));
 }

--- a/src/demo/level.rs
+++ b/src/demo/level.rs
@@ -14,28 +14,9 @@ pub(super) fn plugin(app: &mut App) {
     app.load_resource::<LevelAssets>();
 }
 
-/// A system that spawns the main level.
-pub fn spawn_level(
-    mut commands: Commands,
-    player_assets: Res<PlayerAssets>,
-    mut texture_atlas_layouts: ResMut<Assets<TextureAtlasLayout>>,
-) {
-    commands.spawn((
-        Name::new("Level"),
-        Transform::default(),
-        Visibility::default(),
-        StateScoped(Screen::Gameplay),
-        children![player(400.0, &player_assets, &mut texture_atlas_layouts)],
-    ));
-}
-
-#[derive(Component, Reflect)]
-#[reflect(Component)]
-pub(crate) struct LevelMusicPlayer;
-
 #[derive(Resource, Asset, Clone, Reflect)]
 #[reflect(Resource)]
-pub(crate) struct LevelAssets {
+pub struct LevelAssets {
     #[dependency]
     music: Handle<AudioSource>,
 }
@@ -49,15 +30,24 @@ impl FromWorld for LevelAssets {
     }
 }
 
-pub(crate) fn start_gameplay_music(mut commands: Commands, level_assets: Res<LevelAssets>) {
-    commands.spawn((music(level_assets.music.clone()), LevelMusicPlayer));
-}
-
-pub(crate) fn stop_gameplay_music(
+/// A system that spawns the main level.
+pub fn spawn_level(
     mut commands: Commands,
-    music_players: Query<Entity, With<LevelMusicPlayer>>,
+    player_assets: Res<PlayerAssets>,
+    level_assets: Res<LevelAssets>,
+    mut texture_atlas_layouts: ResMut<Assets<TextureAtlasLayout>>,
 ) {
-    for entity in music_players.iter() {
-        commands.entity(entity).despawn();
-    }
+    commands.spawn((
+        Name::new("Level"),
+        Transform::default(),
+        Visibility::default(),
+        StateScoped(Screen::Gameplay),
+        children![player(400.0, &player_assets, &mut texture_atlas_layouts)],
+    ));
+
+    commands.spawn((
+        Name::new("Level Music"),
+        StateScoped(Screen::Gameplay),
+        music(level_assets.music.clone()),
+    ));
 }

--- a/src/demo/level.rs
+++ b/src/demo/level.rs
@@ -3,9 +3,16 @@
 use bevy::prelude::*;
 
 use crate::{
+    asset_tracking::LoadResource,
+    audio::music,
     demo::player::{PlayerAssets, player},
     screens::Screen,
 };
+
+pub(super) fn plugin(app: &mut App) {
+    app.register_type::<LevelAssets>();
+    app.load_resource::<LevelAssets>();
+}
 
 /// A system that spawns the main level.
 pub fn spawn_level(
@@ -20,4 +27,37 @@ pub fn spawn_level(
         StateScoped(Screen::Gameplay),
         children![player(400.0, &player_assets, &mut texture_atlas_layouts)],
     ));
+}
+
+#[derive(Component, Reflect)]
+#[reflect(Component)]
+pub(crate) struct LevelMusicPlayer;
+
+#[derive(Resource, Asset, Clone, Reflect)]
+#[reflect(Resource)]
+pub(crate) struct LevelAssets {
+    #[dependency]
+    music: Handle<AudioSource>,
+}
+
+impl FromWorld for LevelAssets {
+    fn from_world(world: &mut World) -> Self {
+        let assets = world.resource::<AssetServer>();
+        Self {
+            music: assets.load("audio/music/Fluffing A Duck.ogg"),
+        }
+    }
+}
+
+pub(crate) fn start_gameplay_music(mut commands: Commands, level_assets: Res<LevelAssets>) {
+    commands.spawn((music(level_assets.music.clone()), LevelMusicPlayer));
+}
+
+pub(crate) fn stop_gameplay_music(
+    mut commands: Commands,
+    music_players: Query<Entity, With<LevelMusicPlayer>>,
+) {
+    for entity in music_players.iter() {
+        commands.entity(entity).despawn();
+    }
 }

--- a/src/demo/level.rs
+++ b/src/demo/level.rs
@@ -33,8 +33,8 @@ impl FromWorld for LevelAssets {
 /// A system that spawns the main level.
 pub fn spawn_level(
     mut commands: Commands,
-    player_assets: Res<PlayerAssets>,
     level_assets: Res<LevelAssets>,
+    player_assets: Res<PlayerAssets>,
     mut texture_atlas_layouts: ResMut<Assets<TextureAtlasLayout>>,
 ) {
     commands.spawn((

--- a/src/demo/mod.rs
+++ b/src/demo/mod.rs
@@ -13,8 +13,8 @@ pub mod player;
 pub(super) fn plugin(app: &mut App) {
     app.add_plugins((
         animation::plugin,
+        level::plugin,
         movement::plugin,
         player::plugin,
-        level::plugin,
     ));
 }

--- a/src/demo/mod.rs
+++ b/src/demo/mod.rs
@@ -11,5 +11,10 @@ mod movement;
 pub mod player;
 
 pub(super) fn plugin(app: &mut App) {
-    app.add_plugins((animation::plugin, movement::plugin, player::plugin));
+    app.add_plugins((
+        animation::plugin,
+        movement::plugin,
+        player::plugin,
+        level::plugin,
+    ));
 }

--- a/src/screens/credits.rs
+++ b/src/screens/credits.rs
@@ -7,10 +7,9 @@ use crate::{asset_tracking::LoadResource, audio::music, screens::Screen, theme::
 pub(super) fn plugin(app: &mut App) {
     app.add_systems(OnEnter(Screen::Credits), spawn_credits_screen);
 
-    app.register_type::<CreditsMusic>();
-    app.load_resource::<CreditsMusic>();
+    app.register_type::<CreditsAssets>();
+    app.load_resource::<CreditsAssets>();
     app.add_systems(OnEnter(Screen::Credits), start_credits_music);
-    app.add_systems(OnExit(Screen::Credits), stop_credits_music);
 }
 
 fn spawn_credits_screen(mut commands: Commands) {
@@ -80,29 +79,24 @@ fn enter_title_screen(_: Trigger<Pointer<Click>>, mut next_screen: ResMut<NextSt
 
 #[derive(Resource, Asset, Clone, Reflect)]
 #[reflect(Resource)]
-struct CreditsMusic {
+struct CreditsAssets {
     #[dependency]
-    handle: Handle<AudioSource>,
-    entity: Option<Entity>,
+    music: Handle<AudioSource>,
 }
 
-impl FromWorld for CreditsMusic {
+impl FromWorld for CreditsAssets {
     fn from_world(world: &mut World) -> Self {
         let assets = world.resource::<AssetServer>();
         Self {
-            handle: assets.load("audio/music/Monkeys Spinning Monkeys.ogg"),
-            entity: None,
+            music: assets.load("audio/music/Monkeys Spinning Monkeys.ogg"),
         }
     }
 }
 
-fn start_credits_music(mut commands: Commands, mut credits_music: ResMut<CreditsMusic>) {
-    let handle = credits_music.handle.clone();
-    credits_music.entity = Some(commands.spawn(music(handle)).id());
-}
-
-fn stop_credits_music(mut commands: Commands, mut credits_music: ResMut<CreditsMusic>) {
-    if let Some(entity) = credits_music.entity.take() {
-        commands.entity(entity).despawn();
-    }
+fn start_credits_music(mut commands: Commands, credits_music: Res<CreditsAssets>) {
+    commands.spawn((
+        Name::new("Credits Music"),
+        StateScoped(Screen::Credits),
+        music(credits_music.music.clone()),
+    ));
 }

--- a/src/screens/gameplay.rs
+++ b/src/screens/gameplay.rs
@@ -2,16 +2,10 @@
 
 use bevy::{input::common_conditions::input_just_pressed, prelude::*};
 
-use crate::{
-    demo::level::{spawn_level, start_gameplay_music, stop_gameplay_music},
-    screens::Screen,
-};
+use crate::{demo::level::spawn_level, screens::Screen};
 
 pub(super) fn plugin(app: &mut App) {
     app.add_systems(OnEnter(Screen::Gameplay), spawn_level);
-
-    app.add_systems(OnEnter(Screen::Gameplay), start_gameplay_music);
-    app.add_systems(OnExit(Screen::Gameplay), stop_gameplay_music);
 
     app.add_systems(
         Update,

--- a/src/screens/gameplay.rs
+++ b/src/screens/gameplay.rs
@@ -3,14 +3,13 @@
 use bevy::{input::common_conditions::input_just_pressed, prelude::*};
 
 use crate::{
-    asset_tracking::LoadResource, audio::music, demo::level::spawn_level, screens::Screen,
+    demo::level::{spawn_level, start_gameplay_music, stop_gameplay_music},
+    screens::Screen,
 };
 
 pub(super) fn plugin(app: &mut App) {
     app.add_systems(OnEnter(Screen::Gameplay), spawn_level);
 
-    app.register_type::<GameplayMusic>();
-    app.load_resource::<GameplayMusic>();
     app.add_systems(OnEnter(Screen::Gameplay), start_gameplay_music);
     app.add_systems(OnExit(Screen::Gameplay), stop_gameplay_music);
 
@@ -19,35 +18,6 @@ pub(super) fn plugin(app: &mut App) {
         return_to_title_screen
             .run_if(in_state(Screen::Gameplay).and(input_just_pressed(KeyCode::Escape))),
     );
-}
-
-#[derive(Resource, Asset, Clone, Reflect)]
-#[reflect(Resource)]
-struct GameplayMusic {
-    #[dependency]
-    handle: Handle<AudioSource>,
-    entity: Option<Entity>,
-}
-
-impl FromWorld for GameplayMusic {
-    fn from_world(world: &mut World) -> Self {
-        let assets = world.resource::<AssetServer>();
-        Self {
-            handle: assets.load("audio/music/Fluffing A Duck.ogg"),
-            entity: None,
-        }
-    }
-}
-
-fn start_gameplay_music(mut commands: Commands, mut gameplay_music: ResMut<GameplayMusic>) {
-    let handle = gameplay_music.handle.clone();
-    gameplay_music.entity = Some(commands.spawn(music(handle)).id());
-}
-
-fn stop_gameplay_music(mut commands: Commands, mut gameplay_music: ResMut<GameplayMusic>) {
-    if let Some(entity) = gameplay_music.entity.take() {
-        commands.entity(entity).despawn();
-    }
 }
 
 fn return_to_title_screen(mut next_screen: ResMut<NextState<Screen>>) {


### PR DESCRIPTION
Reasoning:
- The level can decide its own music
- The `LevelAssets` resource is useful in practice, as it will contain the level itself (in e.g. a `Handle<Scene>`) in a real project
- We remove an abstraction (the resource that holds an entity)
- fewer functions overall
- The `spawn_level` function looks less sad :)