### PR TITLE
Use `debuginfo=line-tables-only`

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,8 +7,8 @@ on:
     branches: [main]
 
 env:
-  CARGO_TERM_COLOR: always
-  RUSTFLAGS: --deny warnings -C debuginfo=1
+  # Strip unnecessary information from build artifacts to reduce cache size.
+  RUSTFLAGS: --deny warnings -C debuginfo=line-tables-only
   RUSTDOCFLAGS: --deny warnings
   LINTER_TOOLCHAIN: nightly-2025-04-03
 


### PR DESCRIPTION
Context: https://github.com/TheBevyFlock/bevy_new_2d/pull/396#issuecomment-2863179476.

Also I just came across this relevant section in the GitHub Actions docs: [usage-limits-and-eviction-policy](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/caching-dependencies-to-speed-up-workflows#usage-limits-and-eviction-policy).