### PR TITLE
Update `tooling.md` a bit

### DIFF
--- a/docs/tooling.md
+++ b/docs/tooling.md
@@ -1,5 +1,7 @@
 # Recommended 3rd-party tools
 
+None of these are required, but they can save you a lot of time and effort.
+
 Check out the [Bevy Assets](https://bevyengine.org/assets/) page for more great options.
 
 ## Libraries
@@ -11,36 +13,47 @@ A few libraries that the authors of this template have vetted and think you migh
 | [`leafwing-input-manager`](https://github.com/Leafwing-Studios/leafwing-input-manager) | Input          | Input -> Action mapping               |
 | [`bevy-inspector-egui`](https://github.com/jakobhellermann/bevy-inspector-egui)        | Debugging      | Live entity inspector                 |
 | [`bevy_mod_debugdump`](https://github.com/jakobhellermann/bevy_mod_debugdump)          | Debugging      | Schedule inspector                    |
+| [`inline_tweak`](https://github.com/Uriopass/inline_tweak/)                            | Debugging      | Live tweaking of literal values       |
 | [`avian`](https://github.com/Jondolf/avian)                                            | Physics        | Physics engine                        |
 | [`bevy_rapier`](https://github.com/dimforge/bevy_rapier)                               | Physics        | Physics engine (not ECS-driven)       |
 | [`bevy_common_assets`](https://github.com/NiklasEi/bevy_common_assets)                 | Asset loading  | Asset loaders for common file formats |
 | [`bevy_asset_loader`](https://github.com/NiklasEi/bevy_asset_loader)                   | Asset loading  | Asset management tools                |
 | [`iyes_progress`](https://github.com/IyesGames/iyes_progress)                          | Asset loading  | Progress tracking                     |
-| [`bevy_kira_audio`](https://github.com/NiklasEi/bevy_kira_audio)                       | Audio          | Advanced audio                        |
-| [`bevy_cobweb_ui`](https://github.com/UkoeHB/bevy_cobweb_ui)                           | UI             | UI framework               |
+| [`bevy_kira_audio`](https://github.com/NiklasEi/bevy_kira_audio)                       | Audio          | Advanced audio features               |
+| [`bevy_cobweb_ui`](https://github.com/UkoeHB/bevy_cobweb_ui)                           | UI             | UI framework                          |
 | [`bevy_egui`](https://github.com/mvlabat/bevy_egui)                                    | UI / Debugging | UI framework (great for debug UI)     |
-| [`tiny_bail`](https://github.com/benfrankel/tiny_bail)                                 | Error handling | Error handling macros                 |
+| [`tiny_bail`](https://github.com/benfrankel/tiny_bail)                                 | Error handling | Error handling convenience macros     |
 
 In particular:
 
 - `leafwing-input-manager` is very likely to be upstreamed into Bevy in the near future.
-- `bevy-inspector-egui` and `bevy_mod_debugdump` help fill the gap until Bevy has its own editor.
+- `bevy-inspector-egui`, `bevy_mod_debugdump`, and `inline_tweak` help fill the gap until Bevy has its own editor.
 - `avian` or `bevy_rapier` helps fill the gap until Bevy has its own physics engine. `avian` is easier to use, while `bevy_rapier` is more performant.
 - `bevy_cobweb_ui` is well-aligned with `bevy_ui` and helps fill the gap until Bevy has a full collection of UI widgets and features.
-
-None of these are necessary, but they can save you a lot of time and effort.
 
 ## CLI tools
 
 A few command-line tools that you may find useful:
 
-|Name|Description|
-|-|-|
-|[`bevy_lint`](https://thebevyflock.github.io/bevy_cli/bevy_lint/)|Checks for good practices and footguns specific to Bevy|
+| Name                                                              | Description                                                   |
+|-------------------------------------------------------------------|---------------------------------------------------------------|
+| [`bevy_lint`](https://thebevyflock.github.io/bevy_cli/bevy_lint/) | Checks for good practices and footguns specific to Bevy       |
+| [`oxipng`](https://github.com/shssoichiro/oxipng)                 | Lossless PNG compression (may help reduce file sizes for web) |
+| [`gifski`](https://github.com/ImageOptim/gifski)                  | High-quality GIF encoder (good for animated itch.io content)  |
+
+## Other templates
+
+There are many other Bevy templates out there.
+You can find some of them in the [templates category](https://bevyengine.org/assets/#templates) on Bevy Assets.
+
+> [!TIP]
+> Even if you don't end up using them directly, they can be very helpful as learning material!
+
+# IDE integration
 
 > [!NOTE]
 >
-> `bevy_lint` is run in CI by default (see [workflows](./workflows.md)), but you do not need it to use this template.
+> `bevy_lint` already runs in CI by default (see [workflows](./workflows.md)).
 
 ## VS Code extensions
 
@@ -107,10 +120,3 @@ If you're still having issues, please ensure that the channels in the path and t
 >
 > This does not work for web builds.
 > </details>
-
-
-## Other templates
-
-There are many other Bevy templates out there.
-Check out the [templates category](https://bevyengine.org/assets/#templates) on Bevy Assets for more options.
-Even if you don't end up using them, they are a great way to learn how to implement certain features you might be interested in.

--- a/docs/tooling.md
+++ b/docs/tooling.md
@@ -47,7 +47,7 @@ There are many other Bevy templates out there.
 You can find some of them in the [templates category](https://bevyengine.org/assets/#templates) on Bevy Assets.
 
 > [!TIP]
-> Even if you don't end up using them directly, they can be very useful as learning material!
+> Even if you don't end up using them directly, they can be very helpful as learning material!
 
 # IDE integration
 

--- a/docs/tooling.md
+++ b/docs/tooling.md
@@ -47,7 +47,7 @@ There are many other Bevy templates out there.
 You can find some of them in the [templates category](https://bevyengine.org/assets/#templates) on Bevy Assets.
 
 > [!TIP]
-> Even if you don't end up using them directly, they can be very helpful as learning material!
+> Even if you don't end up using them directly, they can be very useful as learning material!
 
 # IDE integration
 


### PR DESCRIPTION
I wanted to record `oxipng` and `gifski` somewhere relevant so I don't forget about them, and figured they could be useful to others as well.

Summary of changes:
- Added `oxipng` and `gifski` to `CLI tools`
- Added `inline_tweak` to `Libraries`
- Moved `Other templates` section to before IDE integration sections
- Added `# IDE integration` header
- Reworded some things a little bit
