### PR TITLE
Optimize CI speed by a tiny bit

### DIFF
--- a/.cargo/config_ci.toml
+++ b/.cargo/config_ci.toml
@@ -19,6 +19,10 @@ codegen-backend = "llvm"
 [profile.web]
 codegen-backend = "llvm"
 
+# Override the high opt-level from the dev profile for the test profile
+[profile.test.package."*"]
+opt-level = 1
+
 [target.wasm32-unknown-unknown]
 # Clang does not support wasm32-unknown-unknown,
 # so we cannot use mold either: https://github.com/flathub/org.freedesktop.Sdk.Extension.rust-stable/issues/168

--- a/.cargo/config_ci.toml
+++ b/.cargo/config_ci.toml
@@ -20,11 +20,8 @@ codegen-backend = "llvm"
 codegen-backend = "llvm"
 
 # Override the high opt-level from the dev profile for the test profile
-[profile.test]
-opt-level = 0
-
 [profile.test.package."*"]
-opt-level = 0
+opt-level = 1
 
 [target.wasm32-unknown-unknown]
 # Clang does not support wasm32-unknown-unknown,

--- a/.cargo/config_ci.toml
+++ b/.cargo/config_ci.toml
@@ -20,8 +20,11 @@ codegen-backend = "llvm"
 codegen-backend = "llvm"
 
 # Override the high opt-level from the dev profile for the test profile
+[profile.test]
+opt-level = 0
+
 [profile.test.package."*"]
-opt-level = 1
+opt-level = 0
 
 [target.wasm32-unknown-unknown]
 # Clang does not support wasm32-unknown-unknown,

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,7 +7,7 @@ on:
     branches: [main]
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref || github.run_id }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,7 +5,7 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
-    
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
@@ -54,11 +54,11 @@ jobs:
           cache-directories: ${{ steps.ld_library_path.outputs.ld_library_path }}
 
       - name: Run tests
-        run: cargo nextest run --config 'profile.dev.package."*".opt-level=1' --locked --workspace --all-features --all-targets --no-fail-fast --no-tests warn
+        run: cargo nextest run --locked --workspace --all-features --all-targets --no-fail-fast --no-tests warn
 
       # Running doc tests separately is a workaround for <https://github.com/rust-lang/cargo/issues/6669>.
       - name: Run doctests
-        run: cargo test --config 'profile.dev.package."*".opt-level=1' --locked --workspace --all-features --doc
+        run: cargo test --locked --workspace --all-features --doc
 
   # Check that the game builds for web.
   check-web:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,6 +5,10 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+    
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   # Run tests.

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -45,13 +45,12 @@ jobs:
         run: |
           # Setting LD_LIBRARY_PATH is a workaround for <https://github.com/TheBevyFlock/bevy_new_2d/pull/318#issuecomment-2585935350>.
           echo "LD_LIBRARY_PATH=$(rustc --print target-libdir)" >> $GITHUB_ENV
-          echo "ld_library_path=$(rustc --print target-libdir)" >> $GITHUB_OUTPUT
 
       - name: Restore Rust cache
         uses: Swatinem/rust-cache@v2
         with:
           save-if: ${{ github.ref == 'refs/heads/main' }}
-          cache-directories: ${{ steps.ld_library_path.outputs.ld_library_path }}
+          cache-directories: ${{ env.LD_LIBRARY_PATH }}
 
       - name: Run tests
         run: cargo nextest run --locked --workspace --all-features --all-targets --no-fail-fast --no-tests warn

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -31,11 +31,8 @@ jobs:
       - name: Active CI cargo config
         run: mv .cargo/config_ci.toml .cargo/config.toml
 
-      - name: Install cargo binstall
-        uses: cargo-bins/cargo-binstall@main
-
       - name: Install nextest
-        run: cargo binstall cargo-nextest --secure --force
+        uses: taiki-e/install-action@nextest
 
       - name: Install dependencies
         run: sudo apt-get update; sudo apt-get install --no-install-recommends libasound2-dev libudev-dev libwayland-dev libxkbcommon-dev

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -38,10 +38,9 @@ jobs:
         run: sudo apt-get update; sudo apt-get install --no-install-recommends libasound2-dev libudev-dev libwayland-dev libxkbcommon-dev
 
       - name: Set LD_LIBRARY_PATH
-        id: ld_library_path
         run: |
           # Setting LD_LIBRARY_PATH is a workaround for <https://github.com/TheBevyFlock/bevy_new_2d/pull/318#issuecomment-2585935350>.
-          echo "LD_LIBRARY_PATH=$(rustc --print target-libdir)" >> $GITHUB_ENV
+          echo "LD_LIBRARY_PATH=$(rustc --print target-libdir)" >>"${GITHUB_ENV}"
 
       - name: Restore Rust cache
         uses: Swatinem/rust-cache@v2

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -36,18 +36,25 @@ jobs:
       - name: Install dependencies
         run: sudo apt-get update; sudo apt-get install --no-install-recommends libasound2-dev libudev-dev libwayland-dev libxkbcommon-dev
 
+      - name: Set LD_LIBRARY_PATH
+        id: ld_library_path
+        run: |
+          # Setting LD_LIBRARY_PATH is a workaround for <https://github.com/TheBevyFlock/bevy_new_2d/pull/318#issuecomment-2585935350>.
+          echo "LD_LIBRARY_PATH=$(rustc --print target-libdir)" >> $GITHUB_ENV
+          echo "ld_library_path=$(rustc --print target-libdir)" >> $GITHUB_OUTPUT
+
       - name: Restore Rust cache
         uses: Swatinem/rust-cache@v2
         with:
           save-if: ${{ github.ref == 'refs/heads/main' }}
+          cache-directories: ${{ steps.ld_library_path.outputs.ld_library_path }}
 
       - name: Run tests
-        run: cargo nextest run --locked --workspace --all-features --all-targets --no-fail-fast --no-tests warn
+        run: cargo nextest run --config 'profile.dev.package."*".opt-level=1' --locked --workspace --all-features --all-targets --no-fail-fast --no-tests warn
 
       # Running doc tests separately is a workaround for <https://github.com/rust-lang/cargo/issues/6669>.
       - name: Run doctests
-        # Setting LD_LIBRARY_PATH is a workaround for <https://github.com/TheBevyFlock/bevy_new_2d/pull/318#issuecomment-2585935350>.
-        run: LD_LIBRARY_PATH="$(rustc --print target-libdir)" cargo test --locked --workspace --all-features --doc
+        run: cargo test --config 'profile.dev.package."*".opt-level=1' --locked --workspace --all-features --doc
 
   # Check that the game builds for web.
   check-web:


### PR DESCRIPTION
- Cache dynamic libraries
- Compile tests with fewer optimizations
- Disable [concurrent CI runs](https://stackoverflow.com/a/72408109/5903309) on the same branch, PR, or tag
  - This should save computation on private repos