### PR TITLE
Make template more beginner friendly

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -77,7 +77,7 @@ env:
   use_github_cache: false
 
   # Reduce compile time.
-  RUSTFLAGS: -Dwarnings -Zshare-generics=y -Zthreads=0
+  RUSTFLAGS: -Zshare-generics=y -Zthreads=0
 
 jobs:
   # Forward some environment variables as outputs of this job.


### PR DESCRIPTION
I want to suggest we remove `-Dwarnings` as needing to write neat code is a big showstopper in allowing new users to:
- explore and fiddle around
- use this for time-clutched gamejams
- ship ugly code (which should be allowed in my opinion for binary applications, libraries are another story)

Dyonisian Rust Baby! :fire: 