### PR TITLE
Run `bevy_lint` v0.4.0 in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -123,7 +123,10 @@ jobs:
         run: sudo apt-get update; sudo apt-get install --no-install-recommends libasound2-dev libudev-dev libwayland-dev
 
       - name: Install Bevy Lint
-        run: cargo install --git https://github.com/TheBevyFlock/bevy_cli --rev 949b808e6bbf11be0f61b236fbbc4e35854698af --locked bevy_lint
+        uses: TheBevyFlock/bevy_cli/bevy_lint@lint-v0.4.0
+        with:
+          cache: true
+          save-cache-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Run Bevy lints
         run: bevy_lint --locked --workspace --all-targets --profile ci --all-features


### PR DESCRIPTION
In #445 a pinned `bevy_lint` version was used because the previous v0.3.0 version didn't support `let`-chains. Now that v0.4.0 is released, this is no longer necessary! (Plus, there have been several improvements to the action between the pinned commit and v0.4.0's release.)

I enabled the optional caching on `main` for the `bevy_lint` and `bevy_lint_driver` executables, which should speed up CI times at the miniscule cost of ~1.5 MB in cache for all 3 operating systems.

<img width="714" height="215" alt="image" src="https://github.com/user-attachments/assets/a9a46087-6d7e-4493-bdc4-ec46b1e93ba4" />

Definitely also check out the [release page for the list of changes](https://github.com/TheBevyFlock/bevy_cli/releases/tag/lint-v0.4.0)! There's been some cool progress since v0.3.0!