### PR TITLE
Revert obsolete changes to CI from `bevy_lint` updates

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -102,14 +102,11 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Set up environment
-        run: echo "RUSTFLAGS=${RUSTFLAGS:+$RUSTFLAGS }-Zcodegen-backend=cranelift" >> "${GITHUB_ENV}"
-
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@master
+      - name: Install Rust toolchain (plus bevy_lint)
+        uses: TheBevyFlock/bevy_cli/bevy_lint@lint-v0.4.0
         with:
-          components: rustc-codegen-cranelift-preview, rustc-dev, llvm-tools-preview
-          toolchain: ${{ env.toolchain }}
+          cache: true
+          save-cache-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Restore Rust cache
         id: cache
@@ -121,12 +118,6 @@ jobs:
       - name: Install build dependencies
         if: steps.cache.outputs.cache-hit != 'true'
         run: sudo apt-get update; sudo apt-get install --no-install-recommends libasound2-dev libudev-dev libwayland-dev
-
-      - name: Install Bevy Lint
-        uses: TheBevyFlock/bevy_cli/bevy_lint@lint-v0.4.0
-        with:
-          cache: true
-          save-cache-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Run Bevy lints
         run: bevy_lint --locked --workspace --all-targets --profile ci --all-features


### PR DESCRIPTION
See https://github.com/TheBevyFlock/bevy_new_2d/pull/445 and https://github.com/TheBevyFlock/bevy_new_2d/pull/451. If we went straight from v0.3 to v0.4 we would have simply bumped the version number and enabled caching in the `bevy_lint` installation action.