### PR TITLE
Update `config_fast_builds.toml` with upstream changes

### DIFF
--- a/.cargo/config_fast_builds.toml
+++ b/.cargo/config_fast_builds.toml
@@ -7,9 +7,10 @@
 #
 # ## LLD
 #
-# LLD is a linker from the LLVM project that supports Linux, Windows, MacOS, and WASM. It has the greatest
-# platform support and the easiest installation process. It is enabled by default in this file for Linux
-# and Windows. On MacOS, the default linker yields higher performance than LLD and is used instead.
+# LLD is a linker from the LLVM project that supports Linux, Windows, macOS, and Wasm. It has the greatest
+# platform support and the easiest installation process. It is enabled by default in this file for Windows.
+# LLD is the default linker in Rust itself for Linux, so no configuration is needed.
+# On macOS, the default linker yields higher performance than LLD and is used instead.
 #
 # To install, please scroll to the corresponding table for your target (eg. `[target.x86_64-pc-windows-msvc]`
 # for Windows) and follow the steps under `LLD linker`.
@@ -21,11 +22,11 @@
 # Mold is a newer linker written by one of the authors of LLD. It boasts even greater performance, specifically
 # through its high parallelism, though it only supports Linux.
 #
-# Mold is  disabled by default in this file. If you wish to enable it, follow the installation instructions for
-# your corresponding target, disable LLD by commenting out its `-Clink-arg=...` line, and enable Mold by
-# *uncommenting* its `-Clink-arg=...` line.
+# Mold is disabled by default in this file. If you wish to enable it, follow the installation instructions for
+# your corresponding target, disable LLD by commenting out its `-Clink-arg=...` line (not applicable for Linux anymore),
+# and enable Mold by *uncommenting* its `-Clink-arg=...` line.
 #
-# There is a fork of Mold named Sold that supports MacOS, but it is unmaintained and is about the same speed as
+# There is a fork of Mold named Sold that supports macOS, but it is unmaintained and is about the same speed as
 # the default ld64 linker. For this reason, it is not included in this file.
 #
 # For more information, please see Mold's repository at <https://github.com/rui314/mold>.
@@ -51,7 +52,7 @@
 # crates to share monomorphized generic code, so they do not duplicate work.
 #
 # In other words, instead of crate 1 generating `Foo<String>` and crate 2 generating `Foo<String>` separately,
-# only one crate generates `Foo<String>` and the other adds on to the pre-exiting work.
+# only one crate generates `Foo<String>` and the other adds on to the pre-existing work.
 #
 # Note that you may have some issues with this flag on Windows. If compiling fails due to the 65k symbol limit,
 # you may have to disable this setting. For more information and possible solutions to this error, see
@@ -65,17 +66,7 @@
 # For more information, see the blog post at <https://blog.rust-lang.org/2023/11/09/parallel-rustc.html>.
 
 [target.x86_64-unknown-linux-gnu]
-linker = "clang"
 rustflags = [
-  # LLD linker
-  #
-  # You may need to install it:
-  #
-  # - Ubuntu: `sudo apt-get install lld clang`
-  # - Fedora: `sudo dnf install lld clang`
-  # - Arch: `sudo pacman -S lld clang`
-  "-Clink-arg=-fuse-ld=lld",
-
   # Mold linker
   #
   # You may need to install it:
@@ -83,11 +74,17 @@ rustflags = [
   # - Ubuntu: `sudo apt-get install mold clang`
   # - Fedora: `sudo dnf install mold clang`
   # - Arch: `sudo pacman -S mold clang`
-  # "-Clink-arg=-fuse-ld=/usr/bin/mold",
+  # "-Clink-arg=-fuse-ld=mold",
 
   # Nightly
   # "-Zshare-generics=y",
   # "-Zthreads=0",
+]
+# Some systems may experience linker performance issues when running doc tests.
+# See https://github.com/bevyengine/bevy/issues/12207 for details.
+rustdocflags = [
+  # Mold linker
+  # "-Clink-arg=-fuse-ld=mold",
 ]
 
 [target.x86_64-apple-darwin]
@@ -141,7 +138,7 @@ rustflags = [
   # "-Zthreads=0",
 ]
 
-# Optional: Uncommenting the following improves compile times, but reduces the amount of debug info to 'line number tables only'
-# In most cases the gains are negligible, but if you are on macos and have slow compile times you should see significant gains.
+# Optional: Uncommenting the following improves compile times, but reduces the amount of debug info to 'line number tables only'.
+# In most cases the gains are negligible, but if you are on macOS and have slow compile times you should see significant gains.
 # [profile.dev]
 # debug = 1


### PR DESCRIPTION
This updates our copy of `config_fast_builds.toml` to match that of [the engine's version](https://github.com/bevyengine/bevy/blob/3e12f310a42d5edf7dc10642359c1eed38b03094/.cargo/config_fast_builds.toml). Most of the diff is related to docs, but the biggest change is removing the LLD configuration for Linux, [as it's now enabled by default in Rust 1.90.0](https://blog.rust-lang.org/2025/09/01/rust-lld-on-1.90.0-stable/).