### PR TITLE
Fixed inputs context check against strings when they are booleans

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -168,7 +168,7 @@ jobs:
           if [ '${{ matrix.platform }}' != 'windows' ]; then
             RUSTFLAGS="${RUSTFLAGS:+$RUSTFLAGS }"'-Zshare-generics=y'
           fi
-          if [ '${{ inputs.deny_warnings }}' ]; then
+          if [ '${{ inputs.deny_warnings }}' = 'true' ]; then
             RUSTFLAGS="${RUSTFLAGS:+$RUSTFLAGS }"'-Dwarnings'
           fi
           echo "RUSTFLAGS=${RUSTFLAGS}" >> "${GITHUB_ENV}"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -168,7 +168,7 @@ jobs:
           if [ '${{ matrix.platform }}' != 'windows' ]; then
             RUSTFLAGS="${RUSTFLAGS:+$RUSTFLAGS }"'-Zshare-generics=y'
           fi
-          if [ '${{ inputs.deny_warnings }}' = 'true' ]; then
+          if [ '${{ inputs.deny_warnings }}' ]; then
             RUSTFLAGS="${RUSTFLAGS:+$RUSTFLAGS }"'-Dwarnings'
           fi
           echo "RUSTFLAGS=${RUSTFLAGS}" >> "${GITHUB_ENV}"
@@ -307,7 +307,7 @@ jobs:
           retention-days: 1
 
       - name: Upload package to GitHub release
-        if: ${{ env.is_platform_enabled == 'true' && inputs.upload_to_github == 'true' }}
+        if: ${{ env.is_platform_enabled == 'true' && inputs.upload_to_github }}
         uses: svenstaro/upload-release-action@v2
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yaml.template
+++ b/.github/workflows/release.yaml.template
@@ -179,7 +179,7 @@ jobs:
           if [ '${{ matrix.platform }}' != 'windows' ]; then
             RUSTFLAGS="${RUSTFLAGS:+$RUSTFLAGS }"'-Zshare-generics=y'
           fi
-          if [ '${{ inputs.deny_warnings }}' = 'true' ]; then
+          if [ '${{ inputs.deny_warnings }}' ]; then
             RUSTFLAGS="${RUSTFLAGS:+$RUSTFLAGS }"'-Dwarnings'
           fi
           echo "RUSTFLAGS=${RUSTFLAGS}" >> "${GITHUB_ENV}"
@@ -318,7 +318,7 @@ jobs:
           retention-days: 1
 
       - name: Upload package to GitHub release
-        if: ${{ env.is_platform_enabled == 'true' && inputs.upload_to_github == 'true' }}
+        if: ${{ env.is_platform_enabled == 'true' && inputs.upload_to_github }}
         uses: svenstaro/upload-release-action@v2
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yaml.template
+++ b/.github/workflows/release.yaml.template
@@ -179,7 +179,7 @@ jobs:
           if [ '${{ matrix.platform }}' != 'windows' ]; then
             RUSTFLAGS="${RUSTFLAGS:+$RUSTFLAGS }"'-Zshare-generics=y'
           fi
-          if [ '${{ inputs.deny_warnings }}' ]; then
+          if [ '${{ inputs.deny_warnings }}' = 'true' ]; then
             RUSTFLAGS="${RUSTFLAGS:+$RUSTFLAGS }"'-Dwarnings'
           fi
           echo "RUSTFLAGS=${RUSTFLAGS}" >> "${GITHUB_ENV}"


### PR DESCRIPTION
The upload to github releases job does not work currently due to the variable in the ´inputs' context being a boolean and not equal to ´true´. This changes the checks for both ´inputs.upload_to_github` and `inputs.deny_warnings`. Should fix https://github.com/TheBevyFlock/bevy_new_2d/issues/461#issue-3484755689