### PR TITLE
Fix upload to itch.io

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -340,7 +340,7 @@ jobs:
       - name: Download packages
         uses: actions/download-artifact@v4
         with:
-          pattern: package-(windows|macos|linux|web)
+          pattern: package-*
           path: tmp
 
       - name: Install butler

--- a/.github/workflows/release.yaml.template
+++ b/.github/workflows/release.yaml.template
@@ -351,7 +351,7 @@ jobs:
       - name: Download packages
         uses: actions/download-artifact@v4
         with:
-          pattern: package-(windows|macos|linux|web)
+          pattern: package-*
           path: tmp
 
       - name: Install butler


### PR DESCRIPTION
Fixes https://github.com/TheBevyFlock/bevy_new_2d/issues/467.

This was broken by https://github.com/TheBevyFlock/bevy_new_2d/pull/466. The `pattern` input is interpreted as a glob pattern, not a regex (see https://github.com/actions/download-artifact?tab=readme-ov-file#inputs). We can figure this out later when we add more platforms :)