### PR TITLE
Update the Bevy linter to v0.6.0

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -103,7 +103,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install Rust toolchain (plus bevy_lint)
-        uses: TheBevyFlock/bevy_cli/bevy_lint@lint-v0.4.0
+        uses: TheBevyFlock/bevy_cli/bevy_lint@lint-v0.6.0
         with:
           cache: true
           save-cache-if: ${{ github.ref == 'refs/heads/main' }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,7 +15,7 @@ env:
   RUSTFLAGS: -Dwarnings -Zshare-generics=y -Zthreads=0
   RUSTDOCFLAGS: -Dwarnings -Zshare-generics=y -Zthreads=0
   # Use the same Rust toolchain across jobs so they can share a cache.
-  toolchain: nightly-2025-06-26
+  toolchain: nightly-2026-01-22
 
 jobs:
   # Check formatting.


### PR DESCRIPTION
This PR updates the version of the `bevy_lint` used in CI to v0.6.0, which brings support for Bevy 0.18 and a couple of bug fixes. Checkout [the release page](https://github.com/TheBevyFlock/bevy_cli/releases/tag/lint-v0.6.0) for more details :)