### PR TITLE
Fix manual deploy to GitHub Pages

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -339,7 +339,7 @@ jobs:
           retention-days: 1
 
       - name: Upload web bundle to workflow artifacts for GitHub Pages (Web)
-        if: ${{ env.is_platform_enabled == 'true' && matrix.platform == 'web' && (inputs.deploy_to_github_pages == 'true' || (github.event_name == 'push' && needs.forward-env.outputs.continuous_deployment_to_github_pages == 'true')) }}
+        if: ${{ env.is_platform_enabled == 'true' && matrix.platform == 'web' && (inputs.deploy_to_github_pages || (github.event_name == 'push' && needs.forward-env.outputs.continuous_deployment_to_github_pages == 'true')) }}
         uses: actions/upload-pages-artifact@v3
         with:
           path: ${{ env.app }}/${{ env.cargo_build_binary_name }}

--- a/.github/workflows/release.yaml.template
+++ b/.github/workflows/release.yaml.template
@@ -335,7 +335,7 @@ jobs:
           retention-days: 1
 
       - name: Upload web bundle to workflow artifacts for GitHub Pages (Web)
-        if: ${{ env.is_platform_enabled == 'true' && matrix.platform == 'web' && (inputs.deploy_to_github_pages == 'true' || (github.event_name == 'push' && needs.forward-env.outputs.continuous_deployment_to_github_pages == 'true')) }}
+        if: ${{ env.is_platform_enabled == 'true' && matrix.platform == 'web' && (inputs.deploy_to_github_pages || (github.event_name == 'push' && needs.forward-env.outputs.continuous_deployment_to_github_pages == 'true')) }}
         uses: actions/upload-pages-artifact@v3
         with:
           path: ${{ env.app }}/${{ env.cargo_build_binary_name }}


### PR DESCRIPTION
Currently, when I try to deploy the project to GitHub Pages, the `Upload web bundle to workflow artifacts` step is skipped and the `deploy-to-github-pages` fails because it's missing the artifacts.

The problem seems to be that the `inputs.deploy_to_github_pages` is being compared to a string `'true'` instead of being used as a [boolean](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#onworkflow_dispatchinputs). This was introduced in #478 

Tested that the manual deploy works on my project (which doesn't use the full template, I just copied the workflow file)