### PR TITLE
Fix interaction audio playing too often

### DIFF
--- a/src/theme/interaction.rs
+++ b/src/theme/interaction.rs
@@ -88,17 +88,23 @@ impl FromWorld for InteractionAssets {
 }
 
 fn play_sound_effect_on_click(
-    _: On<Pointer<Click>>,
+    on: On<Pointer<Click>>,
     interaction_assets: If<Res<InteractionAssets>>,
+    interaction_entities: Query<Entity, With<InteractionPalette>>,
     mut commands: Commands,
 ) {
-    commands.spawn(sound_effect(interaction_assets.click.clone()));
+    if interaction_entities.contains(on.event_target()) {
+        commands.spawn(sound_effect(interaction_assets.click.clone()));
+    }
 }
 
 fn play_sound_effect_on_over(
-    _: On<Pointer<Over>>,
+    on: On<Pointer<Over>>,
     interaction_assets: If<Res<InteractionAssets>>,
+    interaction_entities: Query<Entity, With<InteractionPalette>>,
     mut commands: Commands,
 ) {
-    commands.spawn(sound_effect(interaction_assets.hover.clone()));
+    if interaction_entities.contains(on.event_target()) {
+        commands.spawn(sound_effect(interaction_assets.hover.clone()));
+    }
 }


### PR DESCRIPTION
This is a bug I noticed while working on my Bevy Jam entry. The hover sound effect was playing whenever the mouse hovers over _any_ UI element, not just interactive ones. Similarly the click sound would play every time mouse1 is pressed.

Video demonstrating the bug:

https://github.com/user-attachments/assets/da0e8ae7-b94f-4250-81bf-87d267960356

The fix is to add a check that the entity the event triggered for has the `InteractionPalette` component